### PR TITLE
chore: GAS版のソースコードをgas/srcディレクトリに移動 #9

### DIFF
--- a/gas/src/appsscript.json
+++ b/gas/src/appsscript.json
@@ -1,0 +1,9 @@
+{
+  "timeZone": "Asia/Tokyo",
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "webapp": {
+    "executeAs": "USER_DEPLOYING",
+    "access": "ANYONE_ANONYMOUS"
+  }
+}

--- a/gas/src/classes/accountBook.js
+++ b/gas/src/classes/accountBook.js
@@ -1,0 +1,268 @@
+class AccountBook { // eslint-disable-line no-unused-vars
+  constructor() {
+    const mainSheet = SpreadsheetApp.openByUrl(PropertiesService.getScriptProperties().getProperty('MAIN_SHEET'));
+    this.variableCostSheet = mainSheet.getSheetByName('家計簿_今月');
+    this.fixedCostSheet = mainSheet.getSheetByName('家計簿_固定費');
+    this.summarySheet = mainSheet.getSheetByName('家計簿_サマリ');
+    this.graph = PropertiesService.getScriptProperties().getProperty('GRAPH_ACCOUNT_BOOK');
+    this.imgUrl = PropertiesService.getScriptProperties().getProperty('IMG_ACCOUNT_BOOK');
+    this.formUrl = PropertiesService.getScriptProperties().getProperty('FORM_ACCOUNT_BOOK');
+    this.user1 = PropertiesService.getScriptProperties().getProperty('USER1_NAME');
+    this.user2 = PropertiesService.getScriptProperties().getProperty('USER2_NAME');
+  }
+
+  /**
+   * チュートリアルに表示するためのテンプレートに利用する配列を取得する
+   *
+   * @return string json配列
+   */
+  getTemplateColumn() {
+    Logger.log('called ' + this.constructor.name + ':getTemplateColumn()');
+    return {
+      "thumbnailImageUrl" : this.imgUrl,
+      "title" : "家計簿管理",
+      "text" : "生活費の報告と、報告内容の確認ができるよ\n毎月25日に決算だよ！",
+      "actions" : [{
+        "type":"message",
+        "label":"使ってみる",
+        "text":"家計簿"
+      }]
+    };
+  }
+
+  /**
+   * 家事管理で利用するボタンテンプレート
+   *
+   * @return string json配列
+   */
+  getButtonTemplateAction() {
+    Logger.log('called ' + this.constructor.name + ':getButtonTemplateAction()');
+    return {
+      "action" : [
+        {
+          "type": "postback",
+          "label": "出費を書き込む",
+          "data": '{"type":"accountBook", "action":"report"}'
+        },{
+          "type": "postback",
+          "label": "報告済の支出を確認する",
+          "data": '{"type":"accountBook", "action":"check"}'
+        },{
+          "type": "postback",
+          "label": "支払額の中間報告を見る",
+          "data": '{"type":"accountBook", "action":"summary"}'
+        }
+      ],
+      "image" : this.imgUrl,
+      "imageAspectRatio" : "square",
+      "imageSize" : "contain",
+      "title" : "家計簿",
+      "altText" : "家計管理テンプレート",
+      "text" : "家計管理だね。\n報告？それとも確認？"
+    };
+  }
+
+  /**
+   * 指定されたアクションに応じたメッセージを返却する
+   *
+   * @param string action アクション
+   * @return string メッセージ
+   */
+  getMessage(action) {
+    Logger.log('called ' + this.constructor.name + ':getMessage()');
+    const dt = new Date();
+    let year = dt.getFullYear();
+    let month = dt.getMonth() + 1;
+
+    if (dt.getDate() >= 26) {
+      month += 1;
+      if (month > 12) {
+        month = 1;
+        year += 1;
+      }
+    }
+
+    const remindComment = '出費は毎月25日までに報告してね！26日に支払い金額を通知するよ！';
+    switch(action) {
+      // 家計簿に記入
+      case 'report':
+        return `家計の報告だね！
+${this.formUrl}?usp=pp_url&entry.220269951=${year}&entry.1155173829=${String(month).padStart(2, '0')}`;
+      // サマリの中間報告
+      case 'summary' :
+      return `現時点での支払内容はこんな感じだよ！
+
+${this.getSummary()}
+毎月と比較してどうかな？
+
+${remindComment}`;
+      case 'check' :
+      return `報告済の支出だよ！
+
+${this.getReported()}
+
+${remindComment}`;
+      default:
+        return 'エラー。意図しないアクションが指定されました。';
+    }
+  }
+
+  /**
+   * 実行時点での報告済家計を取得する
+   */
+   getReported() {
+    Logger.log('called ' + this.constructor.name + ':getReported()');
+
+    const variableCost = this.getVariableCost();
+
+    if (variableCost.length < 1) {
+      return '報告済の支出はないみたい。';
+    }
+
+    let text = '';
+
+    // 変動費の詳細
+    const dt = new Date();
+    for (const key in variableCost) {
+      // 実施日より過去分であれば対象にする
+      if (Number(variableCost[key][1]) <= Number(dt.getFullYear()) && Number(variableCost[key][2]) <= Number(dt.getMonth() + 1)) {
+        text += `${variableCost[key][3]}: ${variableCost[key][4]}円（${variableCost[key][0]}）
+`;
+      }
+    }
+
+    return text;
+   }
+
+  /**
+   * 実行時点での支払いサマリを取得する
+   */
+  getSummary() {
+    Logger.log('called ' + this.constructor.name + ':getSummary()');
+
+    const variableCost = this.getVariableCost();
+    const fixedCost = this.getFixedCost();
+
+    const payment = this.getPayment(variableCost, fixedCost);
+    const detail = this.getDetail(variableCost, fixedCost);
+
+    let text = `${this.user1}さん支払い分 : ${payment['user1']}円
+${this.user2}さん支払い分 : ${payment['user2']}円
+
+支払いの内訳は以下だよ。
+(凡例) [分類] : [価格] （出した人）
+`;
+    for (const key in detail) {
+      text += `${detail[key][0]} : ${detail[key][1]}円 （${detail[key][2]}）\n`;
+    }
+    return text;
+  }
+
+  /**
+   * どちらにいくら払うのか、計算する
+   *
+   * @param array variableCost 変動費
+   * @param array fixedCost 固定費
+   * @retrun array どちらにいくら払うのか、の配列
+   */
+  getPayment(variableCost, fixedCost) {
+    Logger.log('called ' + this.constructor.name + ':getPayment()');
+    let paymentUser1 = 0;
+    let paymentUser2 = 0;
+
+    const dt = new Date();
+    for (const vKey in variableCost) {
+      // 実施日より過去分であれば加算する
+      if (Number(variableCost[vKey][1]) <= Number(dt.getFullYear()) && Number(variableCost[vKey][2]) <= Number(dt.getMonth() + 1)) {
+        if (variableCost[vKey][0] === this.user1) {
+          paymentUser1 += Number(variableCost[vKey][4]);
+        } else if (variableCost[vKey][0] === this.user2) {
+          paymentUser2 += Number(variableCost[vKey][4]);
+        }
+      }
+    }
+
+    // 固定費から家計を計算
+    for (const fKey in fixedCost) {
+      if (fixedCost[fKey][2] === this.user1) {
+        paymentUser1 += Number(fixedCost[fKey][1]);
+      } else if (fixedCost[fKey][2] === this.user2) {
+        paymentUser2 += Number(fixedCost[fKey][1]);
+      }
+    }
+
+    // それぞれの支払った半額を払い合うため、キーと計算に使うユーザーは入れ替える
+    return {
+      'user1': paymentUser2 / 2,
+      'user2': paymentUser1 / 2,
+    };
+  }
+
+  getDetail(variableCost, fixedCost) {
+    Logger.log('called ' + this.constructor.name + ':getDetail()');
+    let detail = [];
+
+    // 変動費の詳細
+    const dt = new Date();
+    for (const key in variableCost) {
+      // 実施日より過去分であれば対象にする
+      if (Number(variableCost[key][1]) <= Number(dt.getFullYear()) && Number(variableCost[key][2]) <= Number(dt.getMonth() + 1)) {
+        if (variableCost[key][0] === this.user2 || variableCost[key][0] === this.user1) {
+          detail.push([
+            variableCost[key][3], // 用途
+            variableCost[key][4], // 額面
+            variableCost[key][0]  // 払った人
+          ]);
+        }
+      }
+    }
+
+    // 固定費の詳細をマージ
+    detail = detail.concat(fixedCost);
+
+    return detail;
+  }
+
+  /**
+   * 変動費を取得
+   */
+  getVariableCost() {
+    Logger.log('called ' + this.constructor.name + ':getVariableCost()');
+    const lastRow = this.variableCostSheet.getLastRow();
+    return lastRow < 1 ? [] : this.variableCostSheet.getRange(1, 1, lastRow, 5).getValues();
+  }
+
+  /**
+   * 固定費を取得
+   */
+  getFixedCost() {
+    Logger.log('called ' + this.constructor.name + ':getFixedCost()');
+    const lastRow = this.fixedCostSheet.getLastRow();
+    return lastRow < 1 ? [] : this.fixedCostSheet.getRange(1, 1, lastRow, 3).getValues();
+  }
+
+  /**
+   * サマリシートを取得
+   */
+  getSummarySheet() {
+    Logger.log('called ' + this.constructor.name + ':getSummarySheet()');
+    return this.summarySheet;
+  }
+
+  /**
+   * 変動費シートを取得
+   */
+  getVariableCostSheet() {
+    Logger.log('called ' + this.constructor.name + ':getVariableCostSheet()');
+    return this.variableCostSheet;
+  }
+
+  /**
+   * グラフのURLを取得（≠シート）
+   */
+  getGraph() {
+    return this.graph;
+  }
+}
+
+module.exports = AccountBook;

--- a/gas/src/classes/chat.js
+++ b/gas/src/classes/chat.js
@@ -1,0 +1,38 @@
+class Chat { // eslint-disable-line no-unused-vars
+  constructor() {
+    this.sheet = SpreadsheetApp.openByUrl(PropertiesService.getScriptProperties().getProperty('MAIN_SHEET')).getSheetByName('うさこの言葉');
+    this.imgUrl = PropertiesService.getScriptProperties().getProperty('IMG_CHAT');
+  }
+
+  /**
+   * チュートリアルに表示するためのテンプレートに利用する配列を取得する
+   *
+   * @return string json配列
+   */
+  getTemplateColumn() {
+    Logger.log('called ' + this.constructor.name + ':getTemplateColumn()');
+    return {
+      "thumbnailImageUrl" : this.imgUrl,
+      "title" : "うさことおしゃべり",
+      "text" : "登録された言葉以外で話しかけると、私とおしゃべりできるよ♪",
+      "actions" : [{
+        "type":"message",
+        "label":"おしゃべり！",
+        "text":"うさこ〜〜〜"
+      }]
+    };
+  }
+
+  /**
+   * ランダムにメッセージを取得する
+   *
+   * @return string メッセージ
+   */
+  getMessage() {
+    Logger.log('called ' + this.constructor.name + ':getMessage()');
+    const message = this.sheet.getRange(1, 1, this.sheet.getLastRow(), 1).getValues();
+    return message[Math.floor(Math.random() * message.length)];
+  }
+}
+
+module.exports = Chat;

--- a/gas/src/classes/commandBase.js
+++ b/gas/src/classes/commandBase.js
@@ -1,0 +1,46 @@
+class commandBase { // eslint-disable-line no-unused-vars
+
+  constructor (name){
+    this.name = name;
+  }
+
+  /**
+   * バッチ実行
+   */
+  main() {
+    try {
+      this.run();
+    } catch (e) {
+      this.notice(e.message, e.stack);
+    } finally {
+      Logger.log('end ' + this.name);
+    }
+  }
+
+  /**
+   * 失敗時の通知
+   *
+   * @param string errorMessage エラーメッセージ
+   * @param string stack スタックトレース
+   */
+  notice(errorMessage, stack) {
+    const line = new LineMessagingApi(); // eslint-disable-line no-undef
+    const message = `${this.name} の実行に失敗しました。
+
+error message: ${errorMessage}
+
+stack trace:
+${stack}`;
+
+    Logger.log(message);
+    line.pushAll(message);
+  }
+
+  /**
+   * 実挙動メソッド。
+   * 内容は継承先のクラスにて実装。
+   */
+  run() {}
+}
+
+module.exports = commandBase;

--- a/gas/src/classes/housework.js
+++ b/gas/src/classes/housework.js
@@ -1,0 +1,156 @@
+class Housework { // eslint-disable-line no-unused-vars
+  constructor() {
+    this.sheet = SpreadsheetApp.openByUrl(PropertiesService.getScriptProperties().getProperty('MAIN_SHEET')).getSheetByName('家事代_今月');
+    this.imgUrl = PropertiesService.getScriptProperties().getProperty('IMG_HOUSEWORK');
+    this.formUrl = PropertiesService.getScriptProperties().getProperty('FORM_HOUSEWORK');
+    this.user1Id = PropertiesService.getScriptProperties().getProperty('USER1_ID');
+    this.user2Id = PropertiesService.getScriptProperties().getProperty('USER2_ID');
+    this.user1Name = PropertiesService.getScriptProperties().getProperty('USER1_NAME');
+    this.user2Name = PropertiesService.getScriptProperties().getProperty('USER2_NAME');
+    this.graph = PropertiesService.getScriptProperties().getProperty('GRAPH_HOUSEWORK');
+  }
+
+  /**
+   * チュートリアルに表示するためのテンプレートに利用する配列を取得する
+   *
+   * @return string json配列
+   */
+  getTemplateColumn() {
+    Logger.log('called ' + this.constructor.name + ':getTemplateColumn()');
+    return {
+      "thumbnailImageUrl" : this.imgUrl,
+      "title" : "家事管理",
+      "text" : "実施した家事の報告や報告内容の確認ができるよ！\n毎週日曜日に決算するよ♪",
+      "actions" : [{
+        "type":"message",
+        "label":"使ってみる",
+        "text":"家事管理"
+      }]
+    };
+  }
+
+  /**
+   * 家事管理で利用するボタンテンプレート
+   *
+   * @return string json配列
+   */
+  getButtonTemplateAction() {
+    Logger.log('called ' + this.constructor.name + ':getButtonTemplateAction()');
+    return {
+      "action" : [
+        {
+          "type": "postback",
+          "label": "実施家事を報告する",
+          "data": '{"type":"housework", "action":"report"}'
+        },
+        {
+          "type": "postback",
+          "label": "報告済家事を確認する",
+          "data": '{"type":"housework", "action":"confirm"}'
+        }
+      ],
+      "image" : this.imgUrl,
+      "imageAspectRatio" : "square",
+      "imageSize" : "contain",
+      "title" : "家事管理",
+      "altText" : "家事管理テンプレート",
+      "text" : "家事管理だね。\n報告？それとも確認？"
+    };
+  }
+
+  /**
+   * アクションに応じたメッセージを取得する
+   * @param string action  実行内容の識別子
+   * @param string userId 送信元のユーザID
+   * @return string 返答
+   */
+  getMessage(action, userId) {
+    Logger.log('called ' + this.constructor.name + ':getMessage()');
+    const dt = new Date();
+    const date = String(dt.getFullYear()) + '-' + String(("0"+(dt.getMonth() + 1)).slice(-2)) + '-' + String(("0"+(dt.getDate())).slice(-2));
+    switch(action) {
+      // 報告済家事の確認
+      case "confirm":
+        return this.getDoneList(userId);
+      // 家事の報告
+      case "report":
+        return `家事報告だね！
+${this.formUrl}?usp=pp_url&entry.1025033203=${date}`;
+      default:
+        return 'エラー。意図しないアクションが指定されました。';
+    }
+  }
+
+  /**
+   * 実行済の家事リストを取得する
+   *
+   * @param string userId 話しかけた人のID
+   * @return string 返事
+   */
+  getDoneList(userId) {
+    Logger.log('called ' + this.constructor.name + ':getDoneList() userId: ' + userId);
+
+    // IDから話しかけた人を特定
+    const userName = userId == this.user1Id ? this.user1Name : this.user2Name;
+
+    // 未実施のときのコメントを設定
+    const messageUnexecuted = '今日はまだ家事をやってないみたい。\n報告するときは、「フォーム」って話しかけてね！';
+
+    const lastRow = this.sheet.getLastRow() - 1;
+    if (lastRow < 2) { // ヘッダ行があるため、報告は2行目以降
+      return messageUnexecuted;
+    }
+    const achievement = this.sheet.getRange(2, 2, lastRow, 5).getValues();
+
+    let text = '報告済の家事はこれだよ！\n';
+    let isDone = false;
+    for (const key in achievement){
+      if (achievement[key][4] == '済') {
+        continue;
+      }
+      // 報告済 && 未支払いの家事をリストに追記する
+      if (String(achievement[key][0]) == String(userName)) {
+        isDone = true;
+        const targetDate = new Date(String(achievement[key][2]));
+        text = text + (targetDate.getMonth() + 1) + '/' + targetDate.getDate() + ' ' + String(achievement[key][1]) + '\n';
+      }
+    }
+
+    // リストの返却
+    if (!isDone) {
+      return messageUnexecuted;
+    }
+    text = text + '\n報告漏れあったかな？';
+    return text;
+  }
+
+  /**
+   * 家事報告のシートを取得する
+   */
+  getSheet() {
+    return this.sheet;
+  }
+
+  /**
+   * ユーザー1の名前を取得する
+   */
+  getUser1Name() {
+    return this.user1Name;
+  }
+
+  /**
+   * ユーザー2の名前を取得する
+   */
+  getUser2Name() {
+    return this.user2Name;
+  }
+
+  /**
+   * グラフのURLを取得（≠シート）
+   */
+  getGraph() {
+    return this.graph;
+  }
+}
+
+module.exports = Housework;

--- a/gas/src/classes/lineMessagingApi.js
+++ b/gas/src/classes/lineMessagingApi.js
@@ -1,0 +1,149 @@
+class LineMessagingApi{ // eslint-disable-line no-unused-vars
+
+  constructor () {
+    this.channelAccessToken = PropertiesService.getScriptProperties().getProperty('CHANNEL_ACCESS_TOKEN');
+  }
+
+  /**
+   * ユーザー全員に向けてpush通知を送信する
+   *
+   * @param string text  送信メッセージの内容
+   */
+  pushAll(text) {
+    Logger.log('called ' + this.constructor.name + ':pushAll()');
+    this.push(text, PropertiesService.getScriptProperties().getProperty('USER1_ID'));
+    this.push(text, PropertiesService.getScriptProperties().getProperty('USER2_ID'));
+  }
+
+  /**
+   * テキストの返信をする
+   *
+   * @param string replyToken 返信用トークン
+   * @param string text 送信文章
+   */
+  replyText(replyToken, text) {
+    Logger.log('called ' + this.constructor.name + ':replyText()');
+    const postData = {
+        "replyToken" : replyToken,
+        "messages" : [
+          {
+              "type" : "text",
+              "text" : String(text)
+          }
+        ]
+    };
+    this.reply(postData);
+  }
+
+  /**
+   * テンプレートボタンメッセージの返信をする
+   *
+   * @param string replyToken 返信用トークン
+   * @param string altText 代替テキスト
+   * @param string thumbnailImageUrl 画像URL
+   * @param string imageAspectRatio 画像のアスペクト比
+   * @param string imageSize 画像の表示形式
+   * @param string title タイトル
+   * @param string text メッセージテキスト
+   * @param string actions タップされたときのアクション
+   */
+  replyTemplateButton(replyToken, altText, thumbnailImageUrl, imageAspectRatio, imageSize, title, text, actions) {
+    Logger.log('called ' + this.constructor.name + ':replyTemplateButton()');
+    const postData = {
+      "replyToken" : replyToken,
+      "messages" : [
+        {
+          "type": "template",
+          "altText": altText,
+          "template": {
+            "type": "buttons",
+            "thumbnailImageUrl": thumbnailImageUrl,
+            "imageAspectRatio": imageAspectRatio,
+            "imageSize": imageSize,
+            "title": title,
+            "text": text,
+            "actions": actions
+          }
+        }
+      ]
+    };
+    this.reply(postData);
+  }
+
+  /**
+   * テンプレートカルーセルメッセージを返信する
+   *
+   * @param string replyToken 返信用トークン
+   * @param array columns カラムオブジェクトの配列
+   */
+  replyTemplateCarousel(replyToken, columns) {
+    Logger.log('called ' + this.constructor.name + ':replyTemplateCarousel()');
+    const postData = {
+      "replyToken" : replyToken,
+      "messages" : [
+        {
+          "type": "template",
+          "altText": '機能一覧の表示',
+          "template": {
+            "type": "carousel",
+            "columns":columns,
+            "imageAspectRatio": 'square',
+            "imageSize" : 'contain'
+          }
+        }
+      ]
+    };
+    this.reply(postData);
+  }
+
+  /**
+   * LINEで返事を送信する
+   *
+   * @param array postData 返信内容の配列
+   */
+  reply(postData) {
+    Logger.log('called ' + this.constructor.name + ':reply()');
+    UrlFetchApp.fetch("https://api.line.me/v2/bot/message/reply", this.getOptions(postData));
+  }
+
+  /**
+   * プッシュメッセージAPI
+   *
+   * @param string text  送信メッセージの内容
+   * @param string to    ユーザID
+   */
+  push(text, to) {
+    Logger.log('called ' + this.constructor.name + ':push()');
+    const postData = {
+      'to' : to,
+      'messages' : [
+        {
+          'type' : 'text',
+          'text' : text
+        }
+      ]
+    };
+    UrlFetchApp.fetch('https://api.line.me/v2/bot/message/push', this.getOptions(postData));
+  }
+
+  /**
+   * 各APIで共通の設定配列を取得する
+   *
+   * @param array postData 送信内容の配列
+   * @return array 設定配列
+   */
+   getOptions(postData) {
+    Logger.log('called ' + this.constructor.name + ':getOptions()');
+     return {
+        'method' : 'post',
+        'headers' : {
+          'Content-Type' : 'application/json',
+          'Authorization' : 'Bearer ' + this.channelAccessToken
+        },
+        'payload' : JSON.stringify(postData),
+        'muteHttpExceptions' : true
+      };
+   }
+}
+
+module.exports = LineMessagingApi;

--- a/gas/src/classes/purchase.js
+++ b/gas/src/classes/purchase.js
@@ -1,0 +1,241 @@
+class Purchase { // eslint-disable-line no-unused-vars
+  constructor() {
+    this.sheet = SpreadsheetApp.openByUrl(PropertiesService.getScriptProperties().getProperty('MAIN_SHEET')).getSheetByName('買い出しリスト');
+    this.imgUrl = PropertiesService.getScriptProperties().getProperty('IMG_PURCHASE');
+
+    // コマンド入力例を定義
+    this.commandSampleAdd =`買い出し
+xxx
+yyy
+欲しい`;
+    this.commandSampleDelete =`買い出し
+xxx
+yyy
+買ったよ`;
+    this.commandSampleList =`買い出し
+リスト`;
+    this.commandSampleDeleteAll =`買い出し
+全消し`;
+  }
+
+  /**
+   * チュートリアルに表示するためのテンプレートに利用する配列を取得する
+   *
+   * @return string json配列
+   */
+  getTemplateColumn() {
+    Logger.log('called ' + this.constructor.name + ':getTemplateColumn()');
+    return {
+      "thumbnailImageUrl" : this.imgUrl,
+      "title" : "買い出しリストの管理",
+      "text" : "買い出しリストの操作ができるよ！\nリストは、2人とも参照可能だよ",
+      "actions" : [{
+        "type" : "message",
+        "label" : "リストを見てみる",
+        "text" : this.commandSampleList
+      }]
+    };
+  }
+
+  /**
+   * コマンド呼び出し
+   *
+   * @param string message 受信したメッセージ
+   * @return string 返信メッセージ
+   */
+  getMessage(message) {
+    Logger.log('called ' + this.constructor.name + ':getMessage()');
+    const splitted = message.split(/\r\n|\n/);
+
+    if (splitted.length < 2) {
+      return `フォーマットエラーだよ！
+以下のいずれかで書いてね。
+
+①リストを確認
+${this.commandSampleList}
+
+②リストから削除
+${this.commandSampleDelete}
+
+③リストに追加
+${this.commandSampleAdd}
+
+③リストから全削除
+${this.commandSampleDeleteAll}
+
+※xxx, yyyには品目名を入力してね。`;
+    }
+
+    splitted.shift(); // 冒頭の `買い出し` を削除
+    const command = String(splitted[splitted.length - 1]);
+    switch (command) {
+      case 'リスト':
+        return this.getList();
+      case '買ったよ':
+        splitted.pop(); // 末尾の `買ったよ` を削除
+        return this.delete(splitted);
+      case '欲しい':
+        splitted.pop(); // 末尾の `欲しい` を削除
+        return this.add(splitted);
+      case '全消し':
+        return this.deleteAll();
+      default:
+        return '「リスト」「買ったよ」「欲しい」のどれかで話しかけて…！！！';
+    }
+  }
+
+  /**
+   * 買い出しリストを取得する
+   *
+   * @return string 買い出しリスト
+   */
+  getList() {
+    Logger.log('called ' + this.constructor.name + ':getList()');
+    const lastRow = this.sheet.getLastRow() - 1;
+    const messageNone = `今登録されている品目はないよ。
+ほしいものがあったら
+
+${this.commandSampleAdd}
+
+で教えてね！`;
+
+    if (lastRow < 1) {
+      return messageNone;
+    }
+    const items = this.sheet.getRange(2, 1, lastRow, 2).getValues();
+
+    let text = `買い出しリストには、いま以下の品目が登録されてるよ！
+
+`;
+    let isNone = true;
+    for(const key in items) {
+      if (items[key][1] != '済') {
+        isNone = false;
+        text += String(items[key][0]) + '\n';
+      }
+    }
+
+    if (isNone) {
+      return messageNone;
+    }
+    text +=`
+買い出しが終わったら
+
+${this.commandSampleDelete}
+
+でリストから削除できるよ！`;
+    return text;
+  }
+
+  /**
+   * 買い出しリストにあるものをすべて削除する
+   */
+  deleteAll() {
+    const messageNoTarget = `まだリストに登録されてるものが無いみたい。
+
+${this.commandSampleList}
+
+でリストにある品目を確認してね`;
+
+    const lastRow = this.sheet.getLastRow() - 1;
+
+    if (lastRow < 1) {
+      return messageNoTarget;
+    }
+
+    const items = this.sheet.getRange(2, 1, lastRow, 2).getValues();
+
+    let isNone = true;
+    for (const itemKey in items) {
+      if (items[itemKey][1] != '済') {
+        isNone = false;
+        const range = this.sheet.getRange(Number(itemKey) + 2, 2);
+        range.setValue('済');
+      }
+    }
+
+    if (isNone) {
+      return messageNoTarget;
+    }
+
+    return 'リストから品目を消しておいたよ〜';
+  }
+
+  /**
+   * 買い出しリストから品目を削除する
+   *
+   * @param array target 削除対象リスト
+   * @return string 実行完了メッセージ
+   */
+  delete(target) {
+    Logger.log('called ' + this.constructor.name + ':delete()');
+    const messageNoTarget = `教えてもらった品目がリストに無いよ！
+
+${this.commandSampleList}
+
+でリストにある品目を確認してね`;
+    const lastRow = this.sheet.getLastRow() - 1;
+
+    if (target.length < 1 || lastRow < 1) {
+      return messageNoTarget;
+    }
+    const items = this.sheet.getRange(2, 1, lastRow, 2).getValues();
+
+    let isNone = true;
+    for (const taegetKey in target) {
+      for (const itemKey in items) {
+        if (items[itemKey][1] != '済' && String(target[taegetKey]) == items[itemKey][0]) {
+          isNone = false;
+          const range = this.sheet.getRange(Number(itemKey) + 2, 2);
+          range.setValue('済');
+        }
+      }
+    }
+
+    if (isNone) {
+      return messageNoTarget;
+    }
+
+    return 'リストから品目を消しておいたよ〜';
+  }
+
+  /**
+   * 買い出しリストに品目追加
+   *
+   * @param array target 追加対象リスト
+   * @return string 実行完了メッセージ
+   */
+  add(target) {
+    Logger.log('called ' + this.constructor.name + ':add()');
+    if (target.length < 1) {
+      return `品目が指定されていないみたいだよ。
+
+${this.commandSampleAdd}
+
+で追加してね！`;
+    }
+
+    for (const key in target) {
+      const lastRow = this.sheet.getLastRow() + 1;
+      this.sheet.setActiveCell('A' + lastRow).setValue(target[key]);
+    }
+
+    return `買い出しリストに追加しておいたよ！
+リストの内容を見るには
+
+${this.commandSampleList}
+
+で教えてね`;
+  }
+
+  /**
+   * 買い出しリストのシートを取得
+   *
+   * @return Sheet 買い出しリスト
+   */
+  getSheet() {
+    return this.sheet;
+  }
+}
+
+module.exports = Purchase;

--- a/gas/src/main.js
+++ b/gas/src/main.js
@@ -1,0 +1,131 @@
+/**
+ * LINEのwebhookに反応する。
+ */
+function doPost(e) { // eslint-disable-line no-unused-vars
+  const posted_json = JSON.parse(e.postData.contents);
+  const events = posted_json.events;
+  const line = new LineMessagingApi(); // eslint-disable-line no-undef
+  Logger.log('called ' + arguments.callee.name);
+  try {
+    events.forEach(function(event) {
+      switch(event.type) {
+        case 'postback':
+          handlePostback_(event.replyToken, event.postback.data, event.source.userId);
+          break;
+        case 'message':
+          handleMessage_(event.message.text, event.replyToken);
+          break;
+        default:
+          line.replyText(event.replyToken, '想定外のイベントが送信されました。');
+          break;
+      }
+    });
+  } catch (e) {
+    const message = `error message: ${e.message}
+
+stack trace:
+${e.stack}`;
+    Logger.log(message);
+  } finally {
+    Logger.log('end ' + arguments.callee.name);
+  }
+}
+
+/**
+ * 選択に対する返事を送信する
+ *
+ * @param string replyToken 返信用トークン
+ * @param string data        送信されたデータ
+ * @param string user_id     送信元のユーザID
+ */
+function handlePostback_(replyToken, data, user_id) {
+  data = JSON.parse(data);
+  let text = '';
+  const accountBook = new AccountBook(); // eslint-disable-line no-undef
+  const housework = new Housework(); // eslint-disable-line no-undef
+  switch(data.type)
+  {
+    case 'housework':
+      text = housework.getMessage(data.action, user_id);
+      break;
+
+    case 'accountBook':
+      text = accountBook.getMessage(data.action);
+      break;
+  }
+  const line = new LineMessagingApi(); // eslint-disable-line no-undef
+  line.replyText(replyToken, text);
+}
+
+/**
+ * 各コマンドに対する応答を管理する
+ *
+ * @param string messageText 受け取った文章
+ * @param string replyToken イベントオブジェクト
+ */
+function handleMessage_(messageText, replyToken) {
+  Logger.log('called ' + arguments.callee.name);
+
+  const line = new LineMessagingApi(); // eslint-disable-line no-undef
+
+  const chat = new Chat(); // eslint-disable-line no-undef
+  const purchase = new Purchase(); // eslint-disable-line no-undef
+  const housework = new Housework(); // eslint-disable-line no-undef
+  const accountBook = new AccountBook(); // eslint-disable-line no-undef
+
+  // コマンド系
+  let action = [];
+  switch(messageText)
+  {
+    case '家事管理' :
+      Logger.log('called ' + arguments.callee.name + ' 家事管理');
+      action = housework.getButtonTemplateAction();
+      line.replyTemplateButton(
+        replyToken,
+        action['altText'],
+        action['image'],
+        action['imageAspectRatio'],
+        action['imageSize'],
+        action['title'],
+        action['text'],
+        action['action']
+      );
+      break;
+
+    case '家計簿' :
+      Logger.log('called ' + arguments.callee.name + ' 家計簿');
+      action = accountBook.getButtonTemplateAction();
+      line.replyTemplateButton(
+        replyToken,
+        action['altText'],
+        action['image'],
+        action['imageAspectRatio'],
+        action['imageSize'],
+        action['title'],
+        action['text'],
+        action['action']
+      );
+      break;
+
+    case 'チュートリアル' :
+      Logger.log('called ' + arguments.callee.name + ' チュートリアル');
+      line.replyTemplateCarousel(
+        replyToken,
+        [
+          housework.getTemplateColumn(),
+          accountBook.getTemplateColumn(),
+          purchase.getTemplateColumn(),
+          chat.getTemplateColumn()
+        ]
+      );
+      break;
+  }
+
+  // 自由記述系
+  if (messageText.match(/買い出し/)) {
+    Logger.log('called ' + arguments.callee.name + ' 買い出し');
+    line.replyText(replyToken, purchase.getMessage(messageText));
+  }
+
+  line.replyText(replyToken, chat.getMessage());
+}

--- a/gas/src/test/accountBook/accountBook.test.js
+++ b/gas/src/test/accountBook/accountBook.test.js
@@ -1,0 +1,300 @@
+const AccountBook = require('../../claasess/accountBook');
+
+// モックの設定
+jest.mock('google-apps-script', () => ({
+  SpreadsheetApp: {
+    openByUrl: jest.fn(),
+    getActiveSpreadsheet: jest.fn(),
+    setActiveSheet: jest.fn(),
+  },
+  PropertiesService: {
+    getScriptProperties: jest.fn(() => ({
+      getProperty: jest.fn((key) => {
+        const properties = {
+          'MAIN_SHEET': 'https://example.com/spreadsheet',
+          'GRAPH_ACCOUNT_BOOK': 'https://example.com/graph',
+          'IMG_ACCOUNT_BOOK': 'https://example.com/image',
+          'FORM_ACCOUNT_BOOK': 'https://example.com/form',
+          'USER1_NAME': 'User1',
+          'USER2_NAME': 'User2',
+        };
+        return properties[key];
+      }),
+    })),
+  },
+}));
+
+describe('AccountBook', () => {
+  let accountBook;
+  let mockSheet;
+  let mockSpreadsheet;
+  let mockProperties;
+  let originalDate;
+
+  beforeEach(() => {
+    mockSheet = {
+      clear: jest.fn(),
+      getLastRow: jest.fn(),
+      getRange: jest.fn(),
+      getValues: jest.fn()
+    };
+    mockSheet.getRange.mockReturnValue({
+      getValues: jest.fn()
+    });
+
+    mockSpreadsheet = {
+      getSheetByName: jest.fn().mockReturnValue(mockSheet)
+    };
+
+    mockProperties = {
+      getProperty: jest.fn().mockImplementation((key) => {
+        switch (key) {
+          case 'GRAPH_ACCOUNT_BOOK':
+            return 'https://example.com/graph';
+          case 'IMG_ACCOUNT_BOOK':
+            return 'https://example.com/image';
+          case 'USER1_NAME':
+            return 'user1';
+          case 'USER2_NAME':
+            return 'user2';
+          default:
+            return '';
+        }
+      })
+    };
+
+    SpreadsheetApp.openByUrl = jest.fn().mockReturnValue(mockSpreadsheet);
+    SpreadsheetApp.getActiveSpreadsheet = jest.fn().mockReturnValue(mockSpreadsheet);
+    PropertiesService.getScriptProperties = jest.fn().mockReturnValue(mockProperties);
+
+    accountBook = new AccountBook();
+  });
+
+  afterEach(() => {
+    if (originalDate) {
+      global.Date = originalDate;
+    }
+  });
+
+  describe('getMessage', () => {
+    describe('26日以降の場合、来月の月を返す', () => {
+      it('1月26日に実行する場合、2月を返す', () => {
+        const mockDate = new Date('2024-01-26');
+        originalDate = global.Date;
+        global.Date = jest.fn(() => mockDate);
+        global.Date.prototype = Object.create(Date.prototype);
+        global.Date.prototype.getDate = jest.fn(() => 26);
+        global.Date.prototype.getMonth = jest.fn(() => 0); // 0-based month (January)
+        global.Date.prototype.getFullYear = jest.fn(() => 2024);
+
+        const result = accountBook.getMessage('report');
+        expect(result).toContain('entry.220269951=2024&entry.1155173829=02');
+      });
+
+      it('12月26日に実行する場合、翌年1月を返す', () => {
+        const mockDate = new Date('2024-12-26');
+        originalDate = global.Date;
+        global.Date = jest.fn(() => mockDate);
+        global.Date.prototype = Object.create(Date.prototype);
+        global.Date.prototype.getDate = jest.fn(() => 26);
+        global.Date.prototype.getMonth = jest.fn(() => 11); // 0-based month (December)
+        global.Date.prototype.getFullYear = jest.fn(() => 2024);
+
+        const result = accountBook.getMessage('report');
+        expect(result).toContain('entry.220269951=2025&entry.1155173829=01');
+      });
+    });
+
+    it('26日以前の場合、今月の月を返す', () => {
+      const mockDate = new Date('2024-12-25');
+      originalDate = global.Date;
+      global.Date = jest.fn(() => mockDate);
+      global.Date.prototype = Object.create(Date.prototype);
+      global.Date.prototype.getDate = jest.fn(() => 25);
+      global.Date.prototype.getMonth = jest.fn(() => 11); // 0-based month (December)
+      global.Date.prototype.getFullYear = jest.fn(() => 2024);
+
+      const result = accountBook.getMessage('report');
+      expect(result).toContain('entry.220269951=2024&entry.1155173829=12');
+    });
+  });
+
+  describe('getTemplateColumn', () => {
+    it('正しいテンプレートを返すこと', () => {
+      const result = accountBook.getTemplateColumn();
+      expect(result).toEqual({
+        "thumbnailImageUrl": "https://example.com/image",
+        "title": "家計簿管理",
+        "text": "生活費の報告と、報告内容の確認ができるよ\n毎月25日に決算だよ！",
+        "actions": [{
+          "type": "message",
+          "label": "使ってみる",
+          "text": "家計簿"
+        }]
+      });
+    });
+  });
+
+  describe('getButtonTemplateAction', () => {
+    it('正しいボタンテンプレートを返すこと', () => {
+      const result = accountBook.getButtonTemplateAction();
+      expect(result).toEqual({
+        "action": [
+          {
+            "type": "postback",
+            "label": "出費を書き込む",
+            "data": '{"type":"accountBook", "action":"report"}'
+          },
+          {
+            "type": "postback",
+            "label": "報告済の支出を確認する",
+            "data": '{"type":"accountBook", "action":"check"}'
+          },
+          {
+            "type": "postback",
+            "label": "支払額の中間報告を見る",
+            "data": '{"type":"accountBook", "action":"summary"}'
+          }
+        ],
+        "image": "https://example.com/image",
+        "imageAspectRatio": "square",
+        "imageSize": "contain",
+        "title": "家計簿",
+        "altText": "家計管理テンプレート",
+        "text": "家計管理だね。\n報告？それとも確認？"
+      });
+    });
+  });
+
+  describe('getReported', () => {
+    it('報告済の支出を正しく取得すること', () => {
+      const mockValues = [
+        ['user1', '2024', '2', '食費', 1000],
+        ['user2', '2024', '2', '雑費', 2000],
+      ];
+      mockSheet.getRange().getValues.mockReturnValue(mockValues);
+
+      const result = accountBook.getReported();
+      expect(result).toBeDefined();
+      expect(result).toContain('食費: 1000円（user1）');
+      expect(result).toContain('雑費: 2000円（user2）');
+    });
+  });
+
+  describe('getSummary', () => {
+    it('サマリを正しく取得すること', () => {
+      const mockValues = [
+        ['食費', 1000],
+        ['雑費', 2000],
+        ['その他', 0],
+        ['ガス', 3000],
+        ['電気', 4000],
+        ['水道', 0],
+        ['嗜好品', 0],
+        ['外食', 0],
+        ['炭酸水', 0],
+        ['車', 0],
+        ['日付', '2024/02'],
+      ];
+      mockSheet.getRange().getValues.mockReturnValue(mockValues);
+
+      const result = accountBook.getSummary();
+      expect(result).toBeDefined();
+      expect(result).toContain('user1さん支払い分 : 0円');
+      expect(result).toContain('user2さん支払い分 : 0円');
+      expect(result).toContain('食費 : 1000円');
+      expect(result).toContain('雑費 : 2000円');
+      expect(result).toContain('ガス : 3000円');
+      expect(result).toContain('電気 : 4000円');
+    });
+  });
+
+  describe('getPayment', () => {
+    it('支払額を正しく計算すること', () => {
+      const variableCost = [
+        ['user1', '2024', '2', '食費', 1000],
+        ['user2', '2024', '2', '雑費', 2000],
+      ];
+      const fixedCost = [
+        ['ガス', 3000, 'user1'],
+        ['電気', 4000, 'user2'],
+      ];
+
+      const result = accountBook.getPayment(variableCost, fixedCost);
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('user1');
+      expect(result).toHaveProperty('user2');
+      expect(result.user1).toBe(3000); // user2の支払いの半額
+      expect(result.user2).toBe(2000); // user1の支払いの半額
+    });
+  });
+
+  describe('getDetail', () => {
+    it('詳細を正しく取得すること', () => {
+      const variableCost = [
+        ['user1', '2024', '2', '食費', 1000],
+        ['user2', '2024', '2', '雑費', 2000],
+      ];
+      const fixedCost = [
+        ['ガス', 3000, 'user1'],
+        ['電気', 4000, 'user2'],
+      ];
+
+      const result = accountBook.getDetail(variableCost, fixedCost);
+      expect(result).toBeDefined();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBe(4);
+      expect(result[0]).toEqual(['食費', 1000, 'user1']);
+      expect(result[1]).toEqual(['雑費', 2000, 'user2']);
+      expect(result[2]).toEqual(['ガス', 3000, 'user1']);
+      expect(result[3]).toEqual(['電気', 4000, 'user2']);
+    });
+  });
+
+  describe('getVariableCost', () => {
+    it('変動費を正しく取得すること', () => {
+      const mockValues = [
+        ['2024', '2', '食費', '食費', 1000],
+        ['2024', '2', '雑費', '雑費', 2000],
+      ];
+      mockSheet.getRange().getValues.mockReturnValue(mockValues);
+
+      const result = accountBook.getVariableCost();
+      expect(result).toEqual(mockValues);
+    });
+  });
+
+  describe('getFixedCost', () => {
+    it('固定費を正しく取得すること', () => {
+      const mockValues = [
+        ['ガス', 3000],
+        ['電気', 4000],
+      ];
+      mockSheet.getRange().getValues.mockReturnValue(mockValues);
+
+      const result = accountBook.getFixedCost();
+      expect(result).toEqual(mockValues);
+    });
+  });
+
+  describe('getSummarySheet', () => {
+    it('サマリシートを正しく取得すること', () => {
+      const result = accountBook.getSummarySheet();
+      expect(result).toBe(mockSheet);
+    });
+  });
+
+  describe('getVariableCostSheet', () => {
+    it('変動費シートを正しく取得すること', () => {
+      const result = accountBook.getVariableCostSheet();
+      expect(result).toBe(mockSheet);
+    });
+  });
+
+  describe('getGraph', () => {
+    it('グラフURLを正しく取得すること', () => {
+      const result = accountBook.getGraph();
+      expect(result).toBe('https://example.com/graph');
+    });
+  });
+}); 

--- a/gas/src/test/accountBook/accountBookSummary.test.js
+++ b/gas/src/test/accountBook/accountBookSummary.test.js
@@ -1,0 +1,232 @@
+const AccountBookSummary = require('../../tasks/accountBook/accountBookSummary');
+const AccountBook = require('../../claasess/accountBook');
+const LineMessagingApi = require('../../claasess/lineMessagingApi');
+
+jest.mock('../../claasess/accountBook');
+jest.mock('../../claasess/lineMessagingApi');
+
+describe('AccountBookSummary', () => {
+  let accountBookSummary;
+  let mockAccountBook;
+  let mockLineMessagingApi;
+  let mockSummarySheet;
+  let mockVariableCostSheet;
+
+  beforeEach(() => {
+    mockSummarySheet = {
+      getRange: jest.fn().mockReturnValue({
+        getValues: jest.fn(),
+        setValue: jest.fn()
+      }),
+      getLastRow: jest.fn(),
+      getLastColumn: jest.fn(),
+    };
+    mockVariableCostSheet = {
+      clear: jest.fn(),
+    };
+    mockAccountBook = {
+      getVariableCost: jest.fn(),
+      getFixedCost: jest.fn(),
+      getSummarySheet: jest.fn().mockReturnValue(mockSummarySheet),
+      getVariableCostSheet: jest.fn().mockReturnValue(mockVariableCostSheet),
+      getSummary: jest.fn(),
+      getGraph: jest.fn(),
+    };
+    mockLineMessagingApi = {
+      pushAll: jest.fn(),
+    };
+
+    AccountBook.mockImplementation(() => mockAccountBook);
+    LineMessagingApi.mockImplementation(() => mockLineMessagingApi);
+
+    accountBookSummary = new AccountBookSummary();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('run', () => {
+    it('正しく実行されること', () => {
+      const mockVariableCost = [
+        ['user1', '2024', '2', '食費', 1000],
+        ['user2', '2024', '2', '雑費', 2000],
+      ];
+      const mockFixedCost = [
+        ['ガス', 3000, 'user1'],
+        ['電気', 4000, 'user2'],
+      ];
+      const mockSummary = 'サマリ内容';
+      const mockGraph = 'https://example.com/graph';
+      const mockIndexes = [
+        ['食費'],
+        ['雑費'],
+        ['ガス'],
+        ['電気'],
+        ['日付'],
+      ];
+
+      mockAccountBook.getVariableCost.mockReturnValue(mockVariableCost);
+      mockAccountBook.getFixedCost.mockReturnValue(mockFixedCost);
+      mockAccountBook.getSummary.mockReturnValue(mockSummary);
+      mockAccountBook.getGraph.mockReturnValue(mockGraph);
+      mockSummarySheet.getLastRow.mockReturnValue(5);
+      mockSummarySheet.getLastColumn.mockReturnValue(1);
+      mockSummarySheet.getRange().getValues.mockReturnValue(mockIndexes);
+
+      accountBookSummary.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledTimes(2);
+      expect(mockVariableCostSheet.clear).toHaveBeenCalled();
+    });
+  });
+
+  describe('aggregate', () => {
+    it('変動費と固定費を正しく集計すること', () => {
+      const dt = new Date('2024-02-01');
+      const variableCost = [
+        ['user1', '2024', '2', '食費', 1000],
+        ['user2', '2024', '2', '雑費', 2000],
+      ];
+      const fixedCost = [
+        ['ガス', 3000, 'user1'],
+        ['電気', 4000, 'user2'],
+      ];
+
+      const result = accountBookSummary.aggregate(dt, variableCost, fixedCost);
+
+      expect(result).toEqual({
+        '食費': 1000,
+        '雑費': 2000,
+        'その他': 0,
+        'ガス': 3000,
+        '電気': 4000,
+        '水道': 0,
+        '車': 0,
+        '嗜好品': 0,
+        '外食': 0,
+        '炭酸水': 0,
+        '日付': '2024/02'
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('サマリシートを正しく更新すること', () => {
+      const mockIndexes = [
+        ['食費'],
+        ['雑費'],
+        ['ガス'],
+        ['電気'],
+        ['日付'],
+      ];
+      const currentData = {
+        '食費': 1000,
+        '雑費': 2000,
+        'ガス': 3000,
+        '電気': 4000,
+        '日付': '2024/02'
+      };
+
+      mockSummarySheet.getLastRow.mockReturnValue(5);
+      mockSummarySheet.getLastColumn.mockReturnValue(1);
+      mockSummarySheet.getRange().getValues.mockReturnValue(mockIndexes);
+
+      accountBookSummary.update(mockSummarySheet, currentData);
+
+      expect(mockSummarySheet.getRange).toHaveBeenCalledTimes(12);
+    });
+  });
+
+  describe('getDiff', () => {
+    it('前月比と前年同月比を正しく計算すること', () => {
+      const mockIndexes = [
+        ['食費'],
+        ['雑費'],
+        ['ガス'],
+        ['電気'],
+        ['日付']
+      ];
+      const mockCurrent = [
+        [1000],
+        [2000],
+        [3000],
+        [4000],
+        ['2024/02']
+      ];
+      const mockLastMonth = [
+        [800],
+        [1800],
+        [3000],
+        [4000],
+        ['2024/01']
+      ];
+      const mockLastYear = [
+        [900],
+        [1900],
+        [3000],
+        [4000],
+        ['2023/02']
+      ];
+
+      mockSummarySheet.getLastRow.mockReturnValue(5);
+      mockSummarySheet.getLastColumn.mockReturnValue(3);
+      mockSummarySheet.getRange().getValues
+        .mockReturnValueOnce(mockIndexes)
+        .mockReturnValueOnce(mockCurrent)
+        .mockReturnValueOnce(mockLastMonth)
+        .mockReturnValueOnce(mockLastYear);
+
+      const result = accountBookSummary.getDiff(mockSummarySheet);
+
+      expect(result).toEqual({
+        lastMonth: {
+          '食費': 200,
+          '雑費': 200,
+          'ガス': 0,
+          '電気': 0
+        },
+        lastYear: {
+          '食費': 100,
+          '雑費': 100,
+          'ガス': 0,
+          '電気': 0
+        }
+      });
+    });
+  });
+
+  describe('getMessage', () => {
+    it('正しいメッセージを生成すること', () => {
+      const diff = {
+        lastMonth: {
+          '食費': 200,
+          '雑費': 200,
+          'ガス': 0,
+          '電気': 0
+        },
+        lastYear: {
+          '食費': 100,
+          '雑費': 100,
+          'ガス': 0,
+          '電気': 0
+        }
+      };
+      const current = {
+        '食費': 1000,
+        '雑費': 2000,
+        'ガス': 3000,
+        '電気': 4000,
+        '日付': '2024/02'
+      };
+      const graph = 'https://example.com/graph';
+
+      const result = accountBookSummary.getMessage(diff, current, graph);
+
+      expect(result).toContain('今月の出費は合計で 10,000 円 でした。');
+      expect(result).toContain('今月は、先月に比べて +400 円 でした。');
+      expect(result).toContain('去年の同じ月と比べると、 200円 の差があるよ！');
+      expect(result).toContain(graph);
+    });
+  });
+}); 

--- a/gas/src/test/chat/chat.test.js
+++ b/gas/src/test/chat/chat.test.js
@@ -1,0 +1,80 @@
+const Chat = require('../../claasess/chat');
+
+jest.mock('../../claasess/commandBase');
+
+describe('Chat', () => {
+  let chat;
+  let mockSheet;
+  let mockProperties;
+
+  beforeEach(() => {
+    // モックの設定
+    mockSheet = {
+      getRange: jest.fn(),
+      getLastRow: jest.fn().mockReturnValue(3),
+    };
+
+    mockProperties = {
+      getScriptProperties: jest.fn().mockReturnValue({
+        getProperty: jest.fn().mockImplementation((key) => {
+          if (key === 'MAIN_SHEET') return 'https://example.com/spreadsheet';
+          if (key === 'IMG_CHAT') return 'https://example.com/image.jpg';
+          return null;
+        }),
+      }),
+    };
+
+    global.SpreadsheetApp = {
+      openByUrl: jest.fn().mockReturnValue({
+        getSheetByName: jest.fn().mockReturnValue(mockSheet),
+      }),
+    };
+
+    global.PropertiesService = mockProperties;
+    global.Logger = {
+      log: jest.fn(),
+    };
+
+    chat = new Chat();
+  });
+
+  describe('getTemplateColumn', () => {
+    it('正しいテンプレートを返すこと', () => {
+      const result = chat.getTemplateColumn();
+
+      expect(result).toEqual({
+        thumbnailImageUrl: 'https://example.com/image.jpg',
+        title: 'うさことおしゃべり',
+        text: '登録された言葉以外で話しかけると、私とおしゃべりできるよ♪',
+        actions: [{
+          type: 'message',
+          label: 'おしゃべり！',
+          text: 'うさこ〜〜〜',
+        }],
+      });
+    });
+  });
+
+  describe('getMessage', () => {
+    it('スプレッドシートからランダムにメッセージを取得すること', () => {
+      const mockMessages = [
+        ['こんにちは'],
+        ['さようなら'],
+        ['おはよう'],
+      ];
+
+      mockSheet.getRange.mockReturnValue({
+        getValues: jest.fn().mockReturnValue(mockMessages),
+      });
+
+      // Math.randomをモック化
+      const mockRandom = jest.spyOn(Math, 'random');
+      mockRandom.mockReturnValue(0.5); // 2番目のメッセージを選択
+
+      const result = chat.getMessage();
+
+      expect(result).toEqual(['さようなら']);
+      expect(mockSheet.getRange).toHaveBeenCalledWith(1, 1, 3, 1);
+    });
+  });
+}); 

--- a/gas/src/test/commandBase/commandBase.test.js
+++ b/gas/src/test/commandBase/commandBase.test.js
@@ -1,0 +1,73 @@
+const CommandBase = require('../../claasess/commandBase');
+
+// LineMessagingApiのモック
+class MockLineMessagingApi {
+  pushAll(message) {
+    this.lastMessage = message;
+  }
+}
+
+describe('CommandBase', () => {
+  let commandBase;
+  let mockLineMessagingApi;
+
+  beforeEach(() => {
+    // LineMessagingApiのモックを設定
+    mockLineMessagingApi = new MockLineMessagingApi();
+    global.LineMessagingApi = jest.fn().mockImplementation(() => mockLineMessagingApi);
+    global.Logger = {
+      log: jest.fn(),
+    };
+
+    commandBase = new CommandBase('テストコマンド');
+  });
+
+  describe('constructor', () => {
+    it('名前が正しく設定されること', () => {
+      expect(commandBase.name).toBe('テストコマンド');
+    });
+  });
+
+  describe('main', () => {
+    it('正常に実行されること', () => {
+      commandBase.run = jest.fn();
+      commandBase.main();
+
+      expect(commandBase.run).toHaveBeenCalled();
+      expect(global.Logger.log).toHaveBeenCalledWith('end テストコマンド');
+    });
+
+    it('エラー時にnoticeが呼ばれること', () => {
+      const error = new Error('テストエラー');
+      error.stack = 'スタックトレース';
+      commandBase.run = jest.fn().mockImplementation(() => {
+        throw error;
+      });
+
+      commandBase.notice = jest.fn();
+      commandBase.main();
+
+      expect(commandBase.notice).toHaveBeenCalledWith('テストエラー', 'スタックトレース');
+      expect(global.Logger.log).toHaveBeenCalledWith('end テストコマンド');
+    });
+  });
+
+  describe('notice', () => {
+    it('エラーメッセージが正しく送信されること', () => {
+      const errorMessage = 'テストエラー';
+      const stack = 'スタックトレース';
+
+      commandBase.notice(errorMessage, stack);
+
+      expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('テストコマンド の実行に失敗しました'));
+      expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('error message: テストエラー'));
+      expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('stack trace:'));
+      expect(global.Logger.log).toHaveBeenCalledWith(expect.stringContaining('スタックトレース'));
+
+      expect(mockLineMessagingApi.lastMessage).toContain('テストコマンド の実行に失敗しました');
+      expect(mockLineMessagingApi.lastMessage).toContain('error message: テストエラー');
+      expect(mockLineMessagingApi.lastMessage).toContain('stack trace:');
+      expect(mockLineMessagingApi.lastMessage).toContain('スタックトレース');
+    });
+  });
+}); 

--- a/gas/src/test/housework/housework.test.js
+++ b/gas/src/test/housework/housework.test.js
@@ -1,0 +1,183 @@
+const Housework = require('../../claasess/housework');
+
+describe('Housework', () => {
+  let housework;
+  let mockSheet;
+  let mockProperties;
+
+  beforeEach(() => {
+    // モックの設定
+    mockSheet = {
+      getRange: jest.fn(),
+      getLastRow: jest.fn().mockReturnValue(3),
+    };
+
+    mockProperties = {
+      getScriptProperties: jest.fn().mockReturnValue({
+        getProperty: jest.fn().mockImplementation((key) => {
+          const properties = {
+            'MAIN_SHEET': 'https://example.com/spreadsheet',
+            'IMG_HOUSEWORK': 'https://example.com/image.jpg',
+            'FORM_HOUSEWORK': 'https://example.com/form',
+            'USER1_ID': 'user1',
+            'USER2_ID': 'user2',
+            'USER1_NAME': 'ユーザー1',
+            'USER2_NAME': 'ユーザー2',
+            'GRAPH_HOUSEWORK': 'https://example.com/graph',
+          };
+          return properties[key] || null;
+        }),
+      }),
+    };
+
+    global.SpreadsheetApp = {
+      openByUrl: jest.fn().mockReturnValue({
+        getSheetByName: jest.fn().mockReturnValue(mockSheet),
+      }),
+    };
+
+    global.PropertiesService = mockProperties;
+    global.Logger = {
+      log: jest.fn(),
+    };
+
+    // Dateをモック化
+    const mockDate = new Date('2024-03-15');
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    housework = new Housework();
+  });
+
+  describe('constructor', () => {
+    it('プロパティが正しく設定されること', () => {
+      expect(housework.imgUrl).toBe('https://example.com/image.jpg');
+      expect(housework.formUrl).toBe('https://example.com/form');
+      expect(housework.user1Id).toBe('user1');
+      expect(housework.user2Id).toBe('user2');
+      expect(housework.user1Name).toBe('ユーザー1');
+      expect(housework.user2Name).toBe('ユーザー2');
+      expect(housework.graph).toBe('https://example.com/graph');
+    });
+  });
+
+  describe('getTemplateColumn', () => {
+    it('正しいテンプレートを返すこと', () => {
+      const result = housework.getTemplateColumn();
+
+      expect(result).toEqual({
+        thumbnailImageUrl: 'https://example.com/image.jpg',
+        title: '家事管理',
+        text: '実施した家事の報告や報告内容の確認ができるよ！\n毎週日曜日に決算するよ♪',
+        actions: [{
+          type: 'message',
+          label: '使ってみる',
+          text: '家事管理',
+        }],
+      });
+    });
+  });
+
+  describe('getButtonTemplateAction', () => {
+    it('正しいボタンテンプレートを返すこと', () => {
+      const result = housework.getButtonTemplateAction();
+
+      expect(result).toEqual({
+        action: [
+          {
+            type: 'postback',
+            label: '実施家事を報告する',
+            data: '{"type":"housework", "action":"report"}',
+          },
+          {
+            type: 'postback',
+            label: '報告済家事を確認する',
+            data: '{"type":"housework", "action":"confirm"}',
+          },
+        ],
+        image: 'https://example.com/image.jpg',
+        imageAspectRatio: 'square',
+        imageSize: 'contain',
+        title: '家事管理',
+        altText: '家事管理テンプレート',
+        text: '家事管理だね。\n報告？それとも確認？',
+      });
+    });
+  });
+
+  describe('getMessage', () => {
+    it('reportアクションで正しいメッセージを返すこと', () => {
+      const result = housework.getMessage('report', 'user1');
+
+      expect(result).toBe('家事報告だね！\nhttps://example.com/form?usp=pp_url&entry.1025033203=2024-03-15');
+    });
+
+    it('confirmアクションでgetDoneListを呼び出すこと', () => {
+      housework.getDoneList = jest.fn().mockReturnValue('テスト用のリスト');
+      const result = housework.getMessage('confirm', 'user1');
+
+      expect(result).toBe('テスト用のリスト');
+      expect(housework.getDoneList).toHaveBeenCalledWith('user1');
+    });
+
+    it('不正なアクションでエラーメッセージを返すこと', () => {
+      const result = housework.getMessage('invalid', 'user1');
+
+      expect(result).toBe('エラー。意図しないアクションが指定されました。');
+    });
+  });
+
+  describe('getDoneList', () => {
+    it('家事が未実施の場合、適切なメッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(1);
+      const result = housework.getDoneList('user1');
+
+      expect(result).toBe('今日はまだ家事をやってないみたい。\n報告するときは、「フォーム」って話しかけてね！');
+    });
+
+    it('実施済みの家事がある場合、リストを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange.mockReturnValue({
+        getValues: jest.fn().mockReturnValue([
+          ['ユーザー1', '掃除', '2024-03-15', '100', '未'],
+          ['ユーザー2', '洗濯', '2024-03-15', '100', '済'],
+        ]),
+      });
+
+      const result = housework.getDoneList('user1');
+
+      expect(result).toBe('報告済の家事はこれだよ！\n3/15 掃除\n\n報告漏れあったかな？');
+    });
+
+    it('実施済みの家事がない場合、未実施メッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange.mockReturnValue({
+        getValues: jest.fn().mockReturnValue([
+          ['ユーザー1', '掃除', '2024-03-15', '100', '済'],
+          ['ユーザー2', '洗濯', '2024-03-15', '100', '済'],
+        ]),
+      });
+
+      const result = housework.getDoneList('user1');
+
+      expect(result).toBe('今日はまだ家事をやってないみたい。\n報告するときは、「フォーム」って話しかけてね！');
+    });
+  });
+
+  describe('getter methods', () => {
+    it('getSheetが正しく動作すること', () => {
+      expect(housework.getSheet()).toBe(mockSheet);
+    });
+
+    it('getUser1Nameが正しく動作すること', () => {
+      expect(housework.getUser1Name()).toBe('ユーザー1');
+    });
+
+    it('getUser2Nameが正しく動作すること', () => {
+      expect(housework.getUser2Name()).toBe('ユーザー2');
+    });
+
+    it('getGraphが正しく動作すること', () => {
+      expect(housework.getGraph()).toBe('https://example.com/graph');
+    });
+  });
+}); 

--- a/gas/src/test/lineMessagingApi/lineMessagingApi.test.js
+++ b/gas/src/test/lineMessagingApi/lineMessagingApi.test.js
@@ -1,0 +1,182 @@
+const LineMessagingApi = require('../../claasess/lineMessagingApi');
+
+describe('LineMessagingApi', () => {
+  let lineMessagingApi;
+  let mockProperties;
+  let mockUrlFetchApp;
+
+  beforeEach(() => {
+    // モックの設定
+    mockProperties = {
+      getScriptProperties: jest.fn().mockReturnValue({
+        getProperty: jest.fn().mockImplementation((key) => {
+          const properties = {
+            'CHANNEL_ACCESS_TOKEN': 'test-token',
+            'USER1_ID': 'user1',
+            'USER2_ID': 'user2',
+          };
+          return properties[key] || null;
+        }),
+      }),
+    };
+
+    mockUrlFetchApp = {
+      fetch: jest.fn(),
+    };
+
+    global.PropertiesService = mockProperties;
+    global.UrlFetchApp = mockUrlFetchApp;
+    global.Logger = {
+      log: jest.fn(),
+    };
+
+    lineMessagingApi = new LineMessagingApi();
+  });
+
+  describe('constructor', () => {
+    it('チャンネルアクセストークンが正しく設定されること', () => {
+      expect(lineMessagingApi.channelAccessToken).toBe('test-token');
+    });
+  });
+
+  describe('pushAll', () => {
+    it('両方のユーザーにメッセージを送信すること', () => {
+      const message = 'テストメッセージ';
+      lineMessagingApi.pushAll(message);
+
+      expect(mockUrlFetchApp.fetch).toHaveBeenCalledTimes(2);
+      expect(mockUrlFetchApp.fetch).toHaveBeenCalledWith(
+        'https://api.line.me/v2/bot/message/push',
+        expect.objectContaining({
+          payload: JSON.stringify({
+            to: 'user1',
+            messages: [{ type: 'text', text: message }],
+          }),
+        })
+      );
+      expect(mockUrlFetchApp.fetch).toHaveBeenCalledWith(
+        'https://api.line.me/v2/bot/message/push',
+        expect.objectContaining({
+          payload: JSON.stringify({
+            to: 'user2',
+            messages: [{ type: 'text', text: message }],
+          }),
+        })
+      );
+    });
+  });
+
+  describe('replyText', () => {
+    it('正しい形式でテキストメッセージを返信すること', () => {
+      const replyToken = 'test-reply-token';
+      const text = 'テストメッセージ';
+      lineMessagingApi.replyText(replyToken, text);
+
+      expect(mockUrlFetchApp.fetch).toHaveBeenCalledWith(
+        'https://api.line.me/v2/bot/message/reply',
+        expect.objectContaining({
+          payload: JSON.stringify({
+            replyToken,
+            messages: [{ type: 'text', text: String(text) }],
+          }),
+        })
+      );
+    });
+  });
+
+  describe('replyTemplateButton', () => {
+    it('正しい形式でボタンテンプレートメッセージを返信すること', () => {
+      const replyToken = 'test-reply-token';
+      const altText = 'テスト代替テキスト';
+      const thumbnailImageUrl = 'https://example.com/image.jpg';
+      const imageAspectRatio = 'square';
+      const imageSize = 'contain';
+      const title = 'テストタイトル';
+      const text = 'テストメッセージ';
+      const actions = [{ type: 'message', label: 'テスト', text: 'テスト' }];
+
+      lineMessagingApi.replyTemplateButton(
+        replyToken,
+        altText,
+        thumbnailImageUrl,
+        imageAspectRatio,
+        imageSize,
+        title,
+        text,
+        actions
+      );
+
+      expect(mockUrlFetchApp.fetch).toHaveBeenCalledWith(
+        'https://api.line.me/v2/bot/message/reply',
+        expect.objectContaining({
+          payload: JSON.stringify({
+            replyToken,
+            messages: [{
+              type: 'template',
+              altText,
+              template: {
+                type: 'buttons',
+                thumbnailImageUrl,
+                imageAspectRatio,
+                imageSize,
+                title,
+                text,
+                actions,
+              },
+            }],
+          }),
+        })
+      );
+    });
+  });
+
+  describe('replyTemplateCarousel', () => {
+    it('正しい形式でカルーセルテンプレートメッセージを返信すること', () => {
+      const replyToken = 'test-reply-token';
+      const columns = [{
+        thumbnailImageUrl: 'https://example.com/image1.jpg',
+        title: 'テスト1',
+        text: 'テストメッセージ1',
+        actions: [{ type: 'message', label: 'テスト1', text: 'テスト1' }],
+      }];
+
+      lineMessagingApi.replyTemplateCarousel(replyToken, columns);
+
+      expect(mockUrlFetchApp.fetch).toHaveBeenCalledWith(
+        'https://api.line.me/v2/bot/message/reply',
+        expect.objectContaining({
+          payload: JSON.stringify({
+            replyToken,
+            messages: [{
+              type: 'template',
+              altText: '機能一覧の表示',
+              template: {
+                type: 'carousel',
+                columns,
+                imageAspectRatio: 'square',
+                imageSize: 'contain',
+              },
+            }],
+          }),
+        })
+      );
+    });
+  });
+
+  describe('getOptions', () => {
+    it('正しいオプションを返すこと', () => {
+      const postData = { test: 'data' };
+      const options = lineMessagingApi.getOptions(postData);
+
+      expect(options).toEqual({
+        method: 'post',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer test-token',
+        },
+        payload: JSON.stringify(postData),
+        muteHttpExceptions: true,
+      });
+    });
+  });
+}); 

--- a/gas/src/test/purchase/purchase.test.js
+++ b/gas/src/test/purchase/purchase.test.js
@@ -1,0 +1,278 @@
+const Purchase = require('../../claasess/purchase');
+
+describe('Purchase', () => {
+  let purchase;
+  let mockSheet;
+  let mockProperties;
+
+  beforeEach(() => {
+    // モックの設定
+    const mockRange = {
+      getValues: jest.fn(),
+      setValue: jest.fn(),
+    };
+
+    mockSheet = {
+      getRange: jest.fn().mockReturnValue(mockRange),
+      getLastRow: jest.fn().mockReturnValue(3),
+      setActiveCell: jest.fn().mockReturnThis(),
+      setValue: jest.fn(),
+    };
+
+    mockProperties = {
+      getScriptProperties: jest.fn().mockReturnValue({
+        getProperty: jest.fn().mockImplementation((key) => {
+          const properties = {
+            'MAIN_SHEET': 'https://example.com/spreadsheet',
+            'IMG_PURCHASE': 'https://example.com/image.jpg',
+          };
+          return properties[key] || null;
+        }),
+      }),
+    };
+
+    global.SpreadsheetApp = {
+      openByUrl: jest.fn().mockReturnValue({
+        getSheetByName: jest.fn().mockReturnValue(mockSheet),
+      }),
+    };
+
+    global.PropertiesService = mockProperties;
+    global.Logger = {
+      log: jest.fn(),
+    };
+
+    purchase = new Purchase();
+  });
+
+  describe('constructor', () => {
+    it('プロパティが正しく設定されること', () => {
+      expect(purchase.imgUrl).toBe('https://example.com/image.jpg');
+      expect(purchase.commandSampleAdd).toBe(`買い出し
+xxx
+yyy
+欲しい`);
+      expect(purchase.commandSampleDelete).toBe(`買い出し
+xxx
+yyy
+買ったよ`);
+      expect(purchase.commandSampleList).toBe(`買い出し
+リスト`);
+      expect(purchase.commandSampleDeleteAll).toBe(`買い出し
+全消し`);
+    });
+  });
+
+  describe('getTemplateColumn', () => {
+    it('正しいテンプレートを返すこと', () => {
+      const result = purchase.getTemplateColumn();
+
+      expect(result).toEqual({
+        thumbnailImageUrl: 'https://example.com/image.jpg',
+        title: '買い出しリストの管理',
+        text: '買い出しリストの操作ができるよ！\nリストは、2人とも参照可能だよ',
+        actions: [{
+          type: 'message',
+          label: 'リストを見てみる',
+          text: purchase.commandSampleList,
+        }],
+      });
+    });
+  });
+
+  describe('getMessage', () => {
+    it('リストコマンドでgetListを呼び出すこと', () => {
+      purchase.getList = jest.fn().mockReturnValue('テスト用のリスト');
+      const result = purchase.getMessage(purchase.commandSampleList);
+
+      expect(result).toBe('テスト用のリスト');
+      expect(purchase.getList).toHaveBeenCalled();
+    });
+
+    it('買ったよコマンドでdeleteを呼び出すこと', () => {
+      purchase.delete = jest.fn().mockReturnValue('テスト用の削除結果');
+      const result = purchase.getMessage(`買い出し
+品物1
+品物2
+買ったよ`);
+
+      expect(result).toBe('テスト用の削除結果');
+      expect(purchase.delete).toHaveBeenCalledWith(['品物1', '品物2']);
+    });
+
+    it('欲しいコマンドでaddを呼び出すこと', () => {
+      purchase.add = jest.fn().mockReturnValue('テスト用の追加結果');
+      const result = purchase.getMessage(`買い出し
+品物1
+品物2
+欲しい`);
+
+      expect(result).toBe('テスト用の追加結果');
+      expect(purchase.add).toHaveBeenCalledWith(['品物1', '品物2']);
+    });
+
+    it('全消しコマンドでdeleteAllを呼び出すこと', () => {
+      purchase.deleteAll = jest.fn().mockReturnValue('テスト用の全削除結果');
+      const result = purchase.getMessage(`買い出し
+全消し`);
+
+      expect(result).toBe('テスト用の全削除結果');
+      expect(purchase.deleteAll).toHaveBeenCalled();
+    });
+
+    it('不正なコマンドでエラーメッセージを返すこと', () => {
+      const result = purchase.getMessage(`買い出し
+不正なコマンド`);
+
+      expect(result).toBe('「リスト」「買ったよ」「欲しい」のどれかで話しかけて…！！！');
+    });
+
+    it('フォーマットエラーでエラーメッセージを返すこと', () => {
+      const result = purchase.getMessage('買い出し');
+
+      expect(result).toContain('フォーマットエラーだよ！');
+      expect(result).toContain('①リストを確認');
+      expect(result).toContain('②リストから削除');
+      expect(result).toContain('③リストに追加');
+      expect(result).toContain('③リストから全削除');
+    });
+  });
+
+  describe('getList', () => {
+    it('リストが空の場合、適切なメッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(1);
+      const result = purchase.getList();
+
+      expect(result).toContain('今登録されている品目はないよ。');
+      expect(result).toContain(purchase.commandSampleAdd);
+    });
+
+    it('リストに未完了の品目がある場合、リストを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '未'],
+        ['品物2', '済'],
+      ]);
+
+      const result = purchase.getList();
+
+      expect(result).toContain('買い出しリストには、いま以下の品目が登録されてるよ！');
+      expect(result).toContain('品物1');
+      expect(result).not.toContain('品物2');
+      expect(result).toContain(purchase.commandSampleDelete);
+    });
+
+    it('リストに未完了の品目がない場合、空のメッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '済'],
+        ['品物2', '済'],
+      ]);
+
+      const result = purchase.getList();
+
+      expect(result).toContain('今登録されている品目はないよ。');
+      expect(result).toContain(purchase.commandSampleAdd);
+    });
+  });
+
+  describe('deleteAll', () => {
+    it('リストが空の場合、適切なメッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(1);
+      const result = purchase.deleteAll();
+
+      expect(result).toContain('まだリストに登録されてるものが無いみたい。');
+      expect(result).toContain(purchase.commandSampleList);
+    });
+
+    it('リストに未完了の品目がある場合、削除して完了メッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '未'],
+        ['品物2', '済'],
+      ]);
+
+      const result = purchase.deleteAll();
+
+      expect(result).toBe('リストから品目を消しておいたよ〜');
+      expect(mockSheet.getRange().setValue).toHaveBeenCalledWith('済');
+    });
+
+    it('リストに未完了の品目がない場合、空のメッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '済'],
+        ['品物2', '済'],
+      ]);
+
+      const result = purchase.deleteAll();
+
+      expect(result).toContain('まだリストに登録されてるものが無いみたい。');
+      expect(result).toContain(purchase.commandSampleList);
+    });
+  });
+
+  describe('delete', () => {
+    it('リストが空の場合、適切なメッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(1);
+      const result = purchase.delete(['品物1']);
+
+      expect(result).toContain('教えてもらった品目がリストに無いよ！');
+      expect(result).toContain(purchase.commandSampleList);
+    });
+
+    it('指定した品目が存在する場合、削除して完了メッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '未'],
+        ['品物2', '済'],
+      ]);
+
+      const result = purchase.delete(['品物1']);
+
+      expect(result).toBe('リストから品目を消しておいたよ〜');
+      expect(mockSheet.getRange().setValue).toHaveBeenCalledWith('済');
+    });
+
+    it('指定した品目が存在しない場合、エラーメッセージを返すこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '済'],
+        ['品物2', '済'],
+      ]);
+
+      const result = purchase.delete(['品物3']);
+
+      expect(result).toContain('教えてもらった品目がリストに無いよ！');
+      expect(result).toContain(purchase.commandSampleList);
+    });
+  });
+
+  describe('add', () => {
+    it('品目が指定されていない場合、エラーメッセージを返すこと', () => {
+      const result = purchase.add([]);
+
+      expect(result).toContain('品目が指定されていないみたいだよ。');
+      expect(result).toContain(purchase.commandSampleAdd);
+    });
+
+    it('品目を追加して完了メッセージを返すこと', () => {
+      const items = ['品物1', '品物2'];
+      const result = purchase.add(items);
+
+      expect(result).toContain('買い出しリストに追加しておいたよ！');
+      expect(result).toContain(purchase.commandSampleList);
+      expect(mockSheet.setActiveCell).toHaveBeenCalledTimes(2);
+      expect(mockSheet.setValue).toHaveBeenCalledTimes(2);
+      items.forEach(item => {
+        expect(mockSheet.setValue).toHaveBeenCalledWith(item);
+      });
+    });
+  });
+
+  describe('getSheet', () => {
+    it('シートを返すこと', () => {
+      expect(purchase.getSheet()).toBe(mockSheet);
+    });
+  });
+}); 

--- a/gas/src/test/tasks/accountBook/accountBookSummary.test.js
+++ b/gas/src/test/tasks/accountBook/accountBookSummary.test.js
@@ -1,0 +1,85 @@
+const AccountBookSummary = require('../../../tasks/accountBook/accountBookSummary');
+
+// SpreadsheetAppをモック化
+global.SpreadsheetApp = {
+  openByUrl: jest.fn().mockReturnValue({
+    getSheetByName: jest.fn().mockReturnValue({
+      getRange: jest.fn().mockReturnValue({
+        getValues: jest.fn(),
+        setValue: jest.fn(),
+      }),
+      getLastColumn: jest.fn().mockReturnValue(5),
+    }),
+  }),
+};
+
+// PropertiesServiceをモック化
+global.PropertiesService = {
+  getScriptProperties: jest.fn().mockReturnValue({
+    getProperty: jest.fn().mockReturnValue('https://example.com/spreadsheet'),
+  }),
+};
+
+// Loggerをモック化
+global.Logger = {
+  log: jest.fn(),
+};
+
+describe('AccountBookSummary', () => {
+  let accountBookSummary;
+  let mockSheet;
+
+  beforeEach(() => {
+    mockSheet = {
+      getRange: jest.fn().mockReturnValue({
+        getValues: jest.fn(),
+        setValue: jest.fn(),
+      }),
+      getLastColumn: jest.fn().mockReturnValue(5),
+    };
+
+    global.SpreadsheetApp.openByUrl().getSheetByName.mockReturnValue(mockSheet);
+
+    accountBookSummary = new AccountBookSummary();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(accountBookSummary.name).toBe('出費のサマリ通知バッチ');
+    });
+  });
+
+  describe('aggregate', () => {
+    it('変動費と固定費を正しく集計すること', () => {
+      const dt = new Date('2025-02-09');
+      const variableCost = [
+        ['2025', '2', '食費', '食費', 1000],
+        ['2025', '2', '雑費', '雑費', 2000],
+      ];
+      const fixedCost = [
+        ['ガス', 3000],
+        ['電気', 4000],
+      ];
+
+      const result = accountBookSummary.aggregate(dt, variableCost, fixedCost);
+
+      expect(result).toEqual({
+        '食費': 0,
+        '雑費': 0,
+        'その他': 0,
+        'ガス': 3000,
+        '電気': 4000,
+        '水道': 0,
+        '嗜好品': 0,
+        '外食': 0,
+        '炭酸水': 0,
+        '車': 0,
+        '日付': '2025/02',
+      });
+    });
+  });
+}); 

--- a/gas/src/test/tasks/accountBook/remindExpenseEntry.test.js
+++ b/gas/src/test/tasks/accountBook/remindExpenseEntry.test.js
@@ -1,0 +1,53 @@
+const RemindExpenseEntry = require('../../../tasks/accountBook/remindExpenseEntry');
+const commandBase = require('../../../claasess/commandBase');
+
+// LineMessagingApiをモック化
+global.LineMessagingApi = jest.fn().mockImplementation(() => ({
+  pushAll: jest.fn(),
+}));
+
+// Loggerをモック化
+global.Logger = {
+  log: jest.fn(),
+};
+
+// commandBaseのmainメソッドをモック化
+jest.spyOn(commandBase.prototype, 'main').mockImplementation(function() {
+  this.run();
+});
+
+describe('RemindExpenseEntry', () => {
+  let remindExpenseEntry;
+  let mockLineMessagingApi;
+
+  beforeEach(() => {
+    mockLineMessagingApi = {
+      pushAll: jest.fn(),
+    };
+
+    global.LineMessagingApi.mockImplementation(() => mockLineMessagingApi);
+
+    remindExpenseEntry = new RemindExpenseEntry();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(remindExpenseEntry.name).toBe('出費入力のリマインドバッチ');
+    });
+  });
+
+  describe('run', () => {
+    it('出費入力のリマインドメッセージを送信すること', () => {
+      remindExpenseEntry.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '今月もおつかれさま！\n出費の報告は26日の18時までに済ませてね。遅れる場合は、翌月の出費として報告してね！\n支払い額の通知、出費全体の通知は26日の19時頃にくるよ！'
+      );
+    });
+  });
+}); 

--- a/gas/src/test/tasks/deletePurchased.test.js
+++ b/gas/src/test/tasks/deletePurchased.test.js
@@ -1,0 +1,77 @@
+const DeletePurchased = require('../../tasks/deletePurchased');
+const Purchase = require('../../claasess/purchase');
+
+jest.mock('../../claasess/purchase');
+
+describe('DeletePurchased', () => {
+  let deletePurchased;
+  let mockSheet;
+  let mockPurchase;
+
+  beforeEach(() => {
+    // モックの設定
+    mockSheet = {
+      getRange: jest.fn().mockReturnValue({
+        getValues: jest.fn(),
+      }),
+      getLastRow: jest.fn().mockReturnValue(3),
+      deleteRow: jest.fn(),
+    };
+
+    mockPurchase = {
+      getSheet: jest.fn().mockReturnValue(mockSheet),
+    };
+
+    Purchase.mockImplementation(() => mockPurchase);
+
+    deletePurchased = new DeletePurchased();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(deletePurchased.name).toBe('買い出しリスト整理バッチ');
+    });
+  });
+
+  describe('run', () => {
+    it('リストが空の場合、何も実行しないこと', () => {
+      mockSheet.getLastRow.mockReturnValue(1);
+      deletePurchased.run();
+
+      expect(mockSheet.deleteRow).not.toHaveBeenCalled();
+    });
+
+    it('完了済みの品目を削除すること', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '未'],
+        ['品物2', '済'],
+        ['品物3', '済'],
+      ]);
+
+      deletePurchased.run();
+
+      expect(mockSheet.deleteRow).toHaveBeenCalledTimes(2);
+      expect(mockSheet.deleteRow).toHaveBeenCalledWith(3); // 品物2の行
+      expect(mockSheet.deleteRow).toHaveBeenCalledWith(4); // 品物3の行
+    });
+
+    it('未完了の品目は削除しないこと', () => {
+      mockSheet.getLastRow.mockReturnValue(3);
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['品物1', '未'],
+        ['品物2', '未'],
+        ['品物3', '済'],
+      ]);
+
+      deletePurchased.run();
+
+      expect(mockSheet.deleteRow).toHaveBeenCalledTimes(1);
+      expect(mockSheet.deleteRow).toHaveBeenCalledWith(4); // 品物3の行のみ
+    });
+  });
+}); 

--- a/gas/src/test/tasks/housework/archiveHouseworks.test.js
+++ b/gas/src/test/tasks/housework/archiveHouseworks.test.js
@@ -1,0 +1,132 @@
+const ArchiveHouseworks = require('../../../tasks/housework/archiveHouseworks');
+const commandBase = require('../../../claasess/commandBase');
+
+// Houseworkをモック化
+global.Housework = jest.fn().mockImplementation(() => ({
+  getSheet: jest.fn(),
+}));
+
+// SpreadsheetAppをモック化
+global.SpreadsheetApp = {
+  setActiveSheet: jest.fn(),
+  getActiveSpreadsheet: jest.fn().mockReturnValue({
+    duplicateActiveSheet: jest.fn().mockReturnValue({
+      setName: jest.fn(),
+    }),
+  }),
+  openByUrl: jest.fn().mockReturnValue({
+    getSheetByName: jest.fn(),
+    deleteSheet: jest.fn(),
+  }),
+  getActive: jest.fn().mockReturnValue({
+    deleteSheet: jest.fn(),
+  }),
+  getActiveSheet: jest.fn().mockReturnValue({
+    getName: jest.fn().mockReturnValue('家事代_202502'),
+  }),
+};
+
+// PropertiesServiceをモック化
+global.PropertiesService = {
+  getScriptProperties: jest.fn().mockReturnValue({
+    getProperty: jest.fn().mockReturnValue('https://example.com/spreadsheet'),
+  }),
+};
+
+// Loggerをモック化
+global.Logger = {
+  log: jest.fn(),
+};
+
+// commandBaseのmainメソッドをモック化
+jest.spyOn(commandBase.prototype, 'main').mockImplementation(function() {
+  this.run();
+});
+
+describe('ArchiveHouseworks', () => {
+  let archiveHouseworks;
+  let mockHousework;
+  let mockSheet;
+  let mockDate;
+
+  beforeEach(() => {
+    mockSheet = {
+      deleteRows: jest.fn(),
+      getLastRow: jest.fn().mockReturnValue(10),
+    };
+
+    mockHousework = {
+      getSheet: jest.fn().mockReturnValue(mockSheet),
+    };
+
+    global.Housework.mockImplementation(() => mockHousework);
+
+    // Dateをモック化
+    mockDate = new Date('2025-02-09'); // 日曜日
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    archiveHouseworks = new ArchiveHouseworks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(archiveHouseworks.name).toBe('家事アーカイブバッチ');
+    });
+  });
+
+  describe('run', () => {
+    it('第一日曜日の場合はアーカイブを実行すること', () => {
+      // 第一日曜日
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(2);
+
+      archiveHouseworks.run();
+
+      expect(global.Logger.log).toHaveBeenCalledWith('called ArchiveHouseworks:run()');
+      expect(mockHousework.getSheet).toHaveBeenCalled();
+      expect(global.SpreadsheetApp.setActiveSheet).toHaveBeenCalledWith(mockSheet);
+      expect(global.SpreadsheetApp.getActiveSpreadsheet().duplicateActiveSheet().setName).toHaveBeenCalledWith('家事代_202502');
+      expect(mockSheet.deleteRows).toHaveBeenCalledWith(2, 9);
+    });
+
+    it('第一日曜日以外の場合はアーカイブを実行しないこと', () => {
+      // 第二日曜日
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(9);
+
+      archiveHouseworks.run();
+
+      expect(global.Logger.log).toHaveBeenCalledWith('called ArchiveHouseworks:run()');
+      expect(mockHousework.getSheet).not.toHaveBeenCalled();
+      expect(global.SpreadsheetApp.setActiveSheet).not.toHaveBeenCalled();
+      expect(global.SpreadsheetApp.getActiveSpreadsheet().duplicateActiveSheet().setName).not.toHaveBeenCalled();
+      expect(mockSheet.deleteRows).not.toHaveBeenCalled();
+    });
+
+    it('前々月分のシートを削除すること', () => {
+      // 第一日曜日
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(2);
+
+      const mockDeleteTargetSheet = {
+        deleteSheet: jest.fn(),
+      };
+
+      global.SpreadsheetApp.openByUrl().getSheetByName.mockReturnValue(mockDeleteTargetSheet);
+
+      archiveHouseworks.run();
+
+      expect(global.SpreadsheetApp.openByUrl).toHaveBeenCalledWith('https://example.com/spreadsheet');
+      expect(global.SpreadsheetApp.openByUrl().getSheetByName).toHaveBeenCalledWith('家事代_202502');
+      expect(global.SpreadsheetApp.getActive().deleteSheet).toHaveBeenCalledWith(mockDeleteTargetSheet);
+    });
+  });
+}); 

--- a/gas/src/test/tasks/housework/noticeInputDoneHouseworks.test.js
+++ b/gas/src/test/tasks/housework/noticeInputDoneHouseworks.test.js
@@ -1,0 +1,74 @@
+const NoticeInputDoneHouseworks = require('../../../tasks/housework/noticeInputDoneHouseworks');
+const commandBase = require('../../../claasess/commandBase');
+
+// LineMessagingApiをモック化
+global.LineMessagingApi = jest.fn().mockImplementation(() => ({
+  pushAll: jest.fn(),
+}));
+
+// Loggerをモック化
+global.Logger = {
+  log: jest.fn(),
+};
+
+// commandBaseのmainメソッドをモック化
+jest.spyOn(commandBase.prototype, 'main').mockImplementation(function() {
+  this.run();
+});
+
+describe('NoticeInputDoneHouseworks', () => {
+  let noticeInputDoneHouseworks;
+  let mockLineMessagingApi;
+  let mockDate;
+
+  beforeEach(() => {
+    mockLineMessagingApi = {
+      pushAll: jest.fn(),
+    };
+
+    global.LineMessagingApi.mockImplementation(() => mockLineMessagingApi);
+
+    // Dateをモック化
+    mockDate = new Date('2025-02-08'); // 土曜日
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    noticeInputDoneHouseworks = new NoticeInputDoneHouseworks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(noticeInputDoneHouseworks.name).toBe('家事入力警告バッチ');
+    });
+  });
+
+  describe('run', () => {
+    it('第一日曜日の前日の場合はアーカイブの通知を送信すること', () => {
+      // 土曜日（翌日が第一日曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(1);
+
+      noticeInputDoneHouseworks.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '2時〜3時の間に今月の家事実績をアーカイブするよ。\n入力は控えてね！'
+      );
+    });
+
+    it('第一日曜日の前日以外の場合は通知を送信しないこと', () => {
+      // 土曜日（翌日が第二日曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(8);
+
+      noticeInputDoneHouseworks.run();
+
+      expect(mockLineMessagingApi.pushAll).not.toHaveBeenCalled();
+    });
+  });
+}); 

--- a/gas/src/test/tasks/housework/notifyHouseworkSummary.test.js
+++ b/gas/src/test/tasks/housework/notifyHouseworkSummary.test.js
@@ -1,0 +1,226 @@
+const NotifyHouseworkSummary = require('../../../tasks/housework/notifyHouseworkSummary');
+const commandBase = require('../../../claasess/commandBase');
+
+// Houseworkをモック化
+global.Housework = jest.fn().mockImplementation(() => ({
+  getSheet: jest.fn(),
+  getUser1Name: jest.fn(),
+  getUser2Name: jest.fn(),
+  getGraph: jest.fn(),
+}));
+
+// LineMessagingApiをモック化
+global.LineMessagingApi = jest.fn().mockImplementation(() => ({
+  pushAll: jest.fn(),
+}));
+
+// SpreadsheetAppをモック化
+global.SpreadsheetApp = {
+  openByUrl: jest.fn().mockReturnValue({
+    getSheetByName: jest.fn().mockReturnValue({
+      getRange: jest.fn().mockReturnValue({
+        getValues: jest.fn().mockReturnValue([['ユーザー1,ユーザー2']]),
+        getValue: jest.fn().mockReturnValue(1000),
+      }),
+      getLastRow: jest.fn().mockReturnValue(5),
+    }),
+  }),
+};
+
+// PropertiesServiceをモック化
+global.PropertiesService = {
+  getScriptProperties: jest.fn().mockReturnValue({
+    getProperty: jest.fn().mockReturnValue('https://example.com/spreadsheet'),
+  }),
+};
+
+// Loggerをモック化
+global.Logger = {
+  log: jest.fn(),
+};
+
+// commandBaseのmainメソッドをモック化
+jest.spyOn(commandBase.prototype, 'main').mockImplementation(function() {
+  this.run();
+});
+
+describe('NotifyHouseworkSummary', () => {
+  let notifyHouseworkSummary;
+  let mockHousework;
+  let mockLineMessagingApi;
+  let mockSheet;
+  let mockDate;
+
+  beforeEach(() => {
+    mockSheet = {
+      getRange: jest.fn().mockReturnValue({
+        getValues: jest.fn(),
+        setValue: jest.fn(),
+      }),
+      getLastRow: jest.fn().mockReturnValue(5),
+    };
+
+    mockHousework = {
+      getSheet: jest.fn().mockReturnValue(mockSheet),
+      getUser1Name: jest.fn().mockReturnValue('ユーザー1'),
+      getUser2Name: jest.fn().mockReturnValue('ユーザー2'),
+      getGraph: jest.fn().mockReturnValue('https://example.com/graph'),
+    };
+
+    mockLineMessagingApi = {
+      pushAll: jest.fn(),
+    };
+
+    global.Housework.mockImplementation(() => mockHousework);
+    global.LineMessagingApi.mockImplementation(() => mockLineMessagingApi);
+
+    // Dateをモック化
+    mockDate = new Date('2025-02-09'); // 日曜日
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    notifyHouseworkSummary = new NotifyHouseworkSummary();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(notifyHouseworkSummary.name).toBe('実施家事のサマリ通知バッチ');
+    });
+  });
+
+  describe('run', () => {
+    it('未通知の家事がある場合はサマリを実行すること', () => {
+      // 未通知の家事データを設定
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['ユーザー1', '掃除', '2025/02/01', '10:00', '済'],
+        ['ユーザー1', '洗濯', '2025/02/02', '11:00', ''],
+        ['ユーザー2', '料理', '2025/02/03', '12:00', ''],
+        ['ユーザー2', '買い物', '2025/02/04', '13:00', '済'],
+      ]);
+
+      notifyHouseworkSummary.run();
+
+      expect(mockHousework.getSheet).toHaveBeenCalled();
+      expect(mockHousework.getUser1Name).toHaveBeenCalled();
+      expect(mockHousework.getUser2Name).toHaveBeenCalled();
+      expect(mockHousework.getGraph).toHaveBeenCalled();
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalled();
+      expect(mockSheet.getRange().setValue).toHaveBeenCalledWith('済');
+    });
+
+    it('未通知の家事がない場合はサマリを実行しないこと', () => {
+      // すべて通知済みの家事データを設定
+      mockSheet.getRange().getValues.mockReturnValue([
+        ['ユーザー1', '掃除', '2025/02/01', '10:00', '済'],
+        ['ユーザー1', '洗濯', '2025/02/02', '11:00', '済'],
+        ['ユーザー2', '料理', '2025/02/03', '12:00', '済'],
+        ['ユーザー2', '買い物', '2025/02/04', '13:00', '済'],
+      ]);
+
+      notifyHouseworkSummary.run();
+
+      expect(mockHousework.getSheet).toHaveBeenCalled();
+      expect(mockHousework.getUser1Name).not.toHaveBeenCalled();
+      expect(mockHousework.getUser2Name).not.toHaveBeenCalled();
+      expect(mockHousework.getGraph).not.toHaveBeenCalled();
+      expect(mockLineMessagingApi.pushAll).not.toHaveBeenCalled();
+      expect(mockSheet.getRange().setValue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUnnotified', () => {
+    it('未通知の家事を正しく取得すること', () => {
+      const reported = [
+        ['ユーザー1', '掃除', '2025/02/01', '10:00', '済'],
+        ['ユーザー1', '洗濯', '2025/02/02', '11:00', ''],
+        ['ユーザー2', '料理', '2025/02/03', '12:00', ''],
+        ['ユーザー2', '買い物', '2025/02/04', '13:00', '済'],
+      ];
+
+      const result = notifyHouseworkSummary.getUnnotified('ユーザー1', reported);
+
+      expect(result).toEqual({
+        user1: ['洗濯'],
+        user2: ['料理'],
+      });
+    });
+  });
+
+  describe('getSummary', () => {
+    it('家事のサマリを正しく取得すること', () => {
+      const user = 'ユーザー1';
+      const context = ['掃除', '掃除', '洗濯'];
+
+      const result = notifyHouseworkSummary.getSummary(user, context);
+
+      expect(result).toHaveProperty('sumMoney');
+      expect(result).toHaveProperty('didCount');
+      expect(result.didCount).toEqual({
+        '掃除': 2,
+        '洗濯': 1,
+      });
+    });
+  });
+
+  describe('getSpendingMoney', () => {
+    it('支払金を正しく取得すること', () => {
+      const mockReferringSheet = {
+        getRange: jest.fn().mockReturnValue({
+          getValues: jest.fn().mockReturnValue([
+            ['掃除', '100', '200'],
+            ['洗濯', '300', '400'],
+          ]),
+          getValue: jest.fn().mockReturnValue('100'),
+        }),
+        getLastRow: jest.fn().mockReturnValue(3),
+      };
+
+      global.SpreadsheetApp.openByUrl().getSheetByName.mockReturnValue(mockReferringSheet);
+
+      const result = notifyHouseworkSummary.getSpendingMoney('ユーザー1', '掃除');
+
+      expect(global.Logger.log).toHaveBeenCalledWith('called NotifyHouseworkSummary: getSpendingMoney() who=ユーザー1, what=掃除');
+      expect(result).toBe('100');
+    });
+  });
+
+  describe('getFormattedMessage', () => {
+    it('メッセージを正しく生成すること', () => {
+      const user1 = 'ユーザー1';
+      const user2 = 'ユーザー2';
+      const summary = {
+        user1: {
+          sumMoney: 1000,
+          didCount: {
+            '掃除': 2,
+            '洗濯': 1,
+          },
+        },
+        user2: {
+          sumMoney: 2000,
+          didCount: {
+            '料理': 3,
+            '買い物': 1,
+          },
+        },
+      };
+      const graph = 'https://example.com/graph';
+
+      const message = notifyHouseworkSummary.getFormattedMessage(user1, user2, summary, graph);
+
+      expect(global.Logger.log).toHaveBeenCalledWith('called NotifyHouseworkSummary:getFormattedMessage()');
+      expect(message).toContain('今週の家事実績報告！');
+      expect(message).toContain('ユーザー1に 1000円');
+      expect(message).toContain('ユーザー2に 2000円');
+      expect(message).toContain('掃除 2回');
+      expect(message).toContain('洗濯 1回');
+      expect(message).toContain('料理 3回');
+      expect(message).toContain('買い物 1回');
+      expect(message).toContain(graph);
+    });
+  });
+}); 

--- a/gas/src/test/tasks/housework/remindInputDoneHouseworks.test.js
+++ b/gas/src/test/tasks/housework/remindInputDoneHouseworks.test.js
@@ -1,0 +1,53 @@
+const RemindInputDoneHouseworks = require('../../../tasks/housework/remindInputDoneHouseworks');
+const commandBase = require('../../../claasess/commandBase');
+
+// LineMessagingApiをモック化
+global.LineMessagingApi = jest.fn().mockImplementation(() => ({
+  pushAll: jest.fn(),
+}));
+
+// Loggerをモック化
+global.Logger = {
+  log: jest.fn(),
+};
+
+// commandBaseのmainメソッドをモック化
+jest.spyOn(commandBase.prototype, 'main').mockImplementation(function() {
+  this.run();
+});
+
+describe('RemindInputDoneHouseworks', () => {
+  let remindInputDoneHouseworks;
+  let mockLineMessagingApi;
+
+  beforeEach(() => {
+    mockLineMessagingApi = {
+      pushAll: jest.fn(),
+    };
+
+    global.LineMessagingApi.mockImplementation(() => mockLineMessagingApi);
+
+    remindInputDoneHouseworks = new RemindInputDoneHouseworks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(remindInputDoneHouseworks.name).toBe('実施済家事入力のリマインドバッチ');
+    });
+  });
+
+  describe('run', () => {
+    it('実施済家事入力のリマインドメッセージを送信すること', () => {
+      remindInputDoneHouseworks.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '今週もおつかれさま！\n家事の報告は今日の12時までに済ませてね。\n遅れると、1時からの集計に間に合わないよ！'
+      );
+    });
+  });
+}); 

--- a/gas/src/test/tasks/noticeTrashDay.test.js
+++ b/gas/src/test/tasks/noticeTrashDay.test.js
@@ -1,0 +1,163 @@
+const NoticeTrashDay = require('../../tasks/noticeTrashDay');
+const commandBase = require('../../claasess/commandBase');
+
+// LineMessagingApiをモック化
+global.LineMessagingApi = jest.fn().mockImplementation(() => ({
+  pushAll: jest.fn(),
+}));
+
+// Loggerをモック化
+global.Logger = {
+  log: jest.fn(),
+};
+
+// commandBaseのmainメソッドをモック化
+jest.spyOn(commandBase.prototype, 'main').mockImplementation(function() {
+  this.run();
+});
+
+describe('NoticeTrashDay', () => {
+  let noticeTrashDay;
+  let mockLineMessagingApi;
+  let mockDate;
+
+  beforeEach(() => {
+    mockLineMessagingApi = {
+      pushAll: jest.fn(),
+    };
+
+    global.LineMessagingApi.mockImplementation(() => mockLineMessagingApi);
+
+    // Dateをモック化
+    mockDate = new Date('2025-02-08'); // 土曜日
+    jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+
+    noticeTrashDay = new NoticeTrashDay();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('正しい名前で初期化されること', () => {
+      expect(noticeTrashDay.name).toBe('ゴミの日通知バッチ');
+    });
+  });
+
+  describe('run', () => {
+    it('月曜日の場合は可燃ごみの通知を送信すること', () => {
+      // 日曜日（翌日が月曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(2);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '明日は 可燃ごみ のゴミの日だよ！\n準備忘れずに！'
+      );
+    });
+
+    it('第一火曜日の場合は資源再生物の通知を送信すること', () => {
+      // 月曜日（翌日が第一火曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(3);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '明日は 資源再生物 のゴミの日だよ！\n準備忘れずに！'
+      );
+    });
+
+    it('第二火曜日の場合は不燃ごみの通知を送信すること', () => {
+      // 月曜日（翌日が第二火曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(10);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '明日は 不燃ごみ のゴミの日だよ！\n準備忘れずに！'
+      );
+    });
+
+    it('第三火曜日の場合は資源再生物の通知を送信すること', () => {
+      // 月曜日（翌日が第三火曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(17);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '明日は 資源再生物 のゴミの日だよ！\n準備忘れずに！'
+      );
+    });
+
+    it('第四火曜日の場合は不燃ごみの通知を送信すること', () => {
+      // 月曜日（翌日が第四火曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(24);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '明日は 不燃ごみ のゴミの日だよ！\n準備忘れずに！'
+      );
+    });
+
+    it('水曜日の場合はプラクルの通知を送信すること', () => {
+      // 火曜日（翌日が水曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(4);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '明日は プラクル のゴミの日だよ！\n準備忘れずに！'
+      );
+    });
+
+    it('木曜日の場合は可燃ごみの通知を送信すること', () => {
+      // 水曜日（翌日が木曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(5);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).toHaveBeenCalledWith(
+        '明日は 可燃ごみ のゴミの日だよ！\n準備忘れずに！'
+      );
+    });
+
+    it('土曜日の場合は通知を送信しないこと', () => {
+      // 金曜日（翌日が土曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(7);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).not.toHaveBeenCalled();
+    });
+
+    it('日曜日の場合は通知を送信しないこと', () => {
+      // 土曜日（翌日が日曜日）
+      mockDate.setFullYear(2025);
+      mockDate.setMonth(1); // 2月
+      mockDate.setDate(8);
+
+      noticeTrashDay.run();
+
+      expect(mockLineMessagingApi.pushAll).not.toHaveBeenCalled();
+    });
+  });
+}); 


### PR DESCRIPTION
リポジトリ構造をモノレポに合わせて整理します。

## 変更内容
- claasess/ディレクトリのファイルをgas/src/classes/ディレクトリに移動
- main.jsをgas/src/ディレクトリに移動
- appsscript.jsonをgas/src/ディレクトリに移動
- テストファイルをgas/src/test/ディレクトリに移動

Resolves #9